### PR TITLE
feat(slack): Slack↔Cognito ユーザーID紐付けでミスマッチを解消

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -1289,3 +1289,19 @@ aidlc-state.md U-06 セクションも本改訂版に合わせて更新済み（
    - モックデータがあれば除去したい
 - GmailやGoogle カレンダー、Goole OAuthとの連携ができていない
 - UI/UXを向上させるポイントとしてID/パスワード認証をやめてパスキー認証にできないか
+
+---
+
+## タスクB: Slack↔Cognito ユーザーIDミスマッチ解消（逆引きまで含む完全版）
+**Timestamp**: 2026-05-23T08:20:00Z
+**User Input**: タスクBスコープ選択 = "逆引きまで含める（GSI＋Webhook＋Agent）"
+**AI Response**: ミスマッチの根本原因を特定 — TaskExtractorLambdaHandler が Slack の user ID を Cognito userId として誤って代入していた（teamId+SlackユーザーID→Cognitoユーザーの逆引き機構が存在しなかった）。完全版で解消（ブランチ `feature/slack-cognito-user-linking`）:
+- shared: User/ServiceConnection 型に slackUserId/slackTeamId（+ slackLookupKey）追加。IServiceConnectionRepository に findCognitoSubBySlackIdentity 追加。
+- CDK: connections テーブルに GSI-SlackLookup（PK=slackLookupKey, KEYS_ONLY）追加。TaskExtractor Lambda に connections Read 権限・テーブル名env追加。
+- backend: DynamoServiceConnectionRepository に slackLookupKey 書き込み＋逆引き実装。auth.ts コールバックで authed_user.id/team.id を取得し User/ServiceConnection に保存。client_id 誤用バグ（COGNITO_CLIENT_ID 死にコード）を整理。
+- agent: DynamoSlackUserLookupRepository を新規作成。TaskExtractorLambdaHandler で逆引きし payload.userId に Cognito sub を設定。未連携 Slack ユーザーは安全にスキップ。
+品質確認: shared 103 / backend 199 / agent 155 全テストパス（agent カバレッジ100%維持）。型チェック・CDK synth・ビルド OK。Biome エラー総数 変更前179→変更後168（悪化なし）。
+設計詳細は aidlc-docs/construction/slack-cognito-linking/design.md。
+**Context**: タスクB実装完了。コミット・PR待ち。
+
+---

--- a/aidlc-docs/construction/slack-cognito-linking/design.md
+++ b/aidlc-docs/construction/slack-cognito-linking/design.md
@@ -1,0 +1,114 @@
+# タスクB 設計：Slack ↔ Cognito ユーザーID 紐付け
+
+**作成日**: 2026-05-23
+**ブランチ**: `feature/slack-cognito-user-linking`
+**スコープ**: 逆引きまで含む完全版（GSI + Webhook/Agent 経路の改修）
+
+---
+
+## 問題の本質（実コードで特定済み）
+
+Slack イベントは `teamId` と Slack の `user` ID しか持たない。しかし、それを処理するパイプラインは Cognito の `userId` を必要とする。両者を紐付ける仕組みが無いため、**Slack の user ID が Cognito userId として誤って扱われている**。
+
+### 決定的なバグ箇所
+
+`pkgs/agent/src/task-extractor/TaskExtractorLambdaHandler.ts:60-71`:
+```ts
+const payload: SlackEventPayload = {
+  source: "slack",
+  userId: rawEvent.user,   // ← Slack user ID を Cognito userId として代入（バグ）
+  message: { userId: rawEvent.user, teamId: detail.teamId, ... },
+};
+```
+
+結果、TaskCandidate が `userId = SlackユーザーID` で保存され、`GSI-UserCreatedAt` でCognitoユーザーが自分のタスクを取得できない（ミスマッチ）。
+
+### 付随バグ
+
+`pkgs/backend/src/routes/auth.ts:87`:
+```ts
+const clientId = env.COGNITO_CLIENT_ID; // Slack 用なのに Cognito の client_id（誤用・未使用）
+```
+実際の `GET /auth/slack` は `process.env.SLACK_CLIENT_ID ?? ""` を使う（`auth.ts:103`）。矛盾コードを整理する。
+
+---
+
+## データフロー（改修後）
+
+```
+Slack message
+  │ event.user (Slack), team_id (Slack)
+  ▼
+webhooks.ts → EventBridge Detail { event, teamId, receivedAt }
+  ▼
+TaskExtractorLambdaHandler
+  │ ★ ここで (teamId + event.user) → cognitoSub を逆引き
+  │   見つからなければスキップ（未連携ユーザーのメッセージ）
+  ▼
+SlackEventPayload { userId: cognitoSub, message: { userId: slackUserId, teamId } }
+  ▼
+TaskExtractorAgent → TaskCandidate (userId = cognitoSub で保存) ✅
+```
+
+逆引きの鍵: OAuth 連携時に「どの Cognito ユーザーが、どの Slack team の、どの Slack user か」を保存しておく。
+
+---
+
+## 変更一覧
+
+### 1. shared（型）
+- `User` 型に `slackUserId?: string` / `slackTeamId?: string` を追加（オプショナル＝既存互換）
+- `ServiceConnection` 型に `slackUserId?: string` / `slackTeamId?: string` を追加
+- `IServiceConnectionRepository` に逆引きメソッド `findCognitoSubBySlackIdentity(teamId, slackUserId): Promise<string | null>` を追加
+
+### 2. CDK（インフラ）
+- `data-stack.ts`: connections テーブルに **GSI `GSI-SlackLookup`** を追加
+  - PK: `slackLookupKey`（= `${slackTeamId}#${slackUserId}` の合成属性）
+  - 射影: `KEYS_ONLY`（cognitoSub は PK `USER#<sub>` から復元可能）または `INCLUDE` で cognitoSub
+  - 設計: 合成キー属性 `slackLookupKey` を保存時に書き込む
+- `webhook-stack.ts` または `agent-stack.ts`: TaskExtractor Lambda に connections テーブル + GSI の Read 権限を付与
+  - ※ 逆引きは TaskExtractorLambdaHandler で行うため、AgentStack の TaskExtractor に権限付与
+
+### 3. backend
+- `auth.ts`:
+  - OAuth コールバックで `oauth.v2.access` レスポンスから `authed_user.id`・`team.id` を取得
+  - User を upsert（slackUserId/slackTeamId 付き）
+  - ServiceConnection を保存（slackUserId/slackTeamId/slackLookupKey 付き）
+  - client_id 誤用バグ（`auth.ts:87`）を整理
+- `DynamoServiceConnectionRepository.ts`:
+  - `saveForUser` で `slackLookupKey` 合成属性を書き込む
+  - `findCognitoSubBySlackIdentity(teamId, slackUserId)` を GSI Query で実装
+- `DynamoUserRepository` は型追加に追従（upsert がそのまま slackUserId/slackTeamId を保存）
+
+### 4. agent
+- `TaskExtractorLambdaHandler.ts`:
+  - connections テーブルへアクセスする逆引きリポジトリを初期化
+  - `(detail.teamId + rawEvent.user)` から cognitoSub を逆引き
+  - 見つからなければ `logInfo({ action: "skipped_unlinked_slack_user" })` でスキップ（未連携ユーザー）
+  - `payload.userId = cognitoSub`、`message.userId = rawEvent.user`（Slack ID は仮名化用に保持）
+
+### 5. テスト
+- shared: 型変更に伴う既存テストの追従
+- backend: auth コールバック（authed_user 保存）、Repository 逆引き、connectionsの slackLookupKey 書き込み
+- agent: TaskExtractorLambdaHandler の逆引き成功/失敗（未連携スキップ）
+
+---
+
+## 設計判断・留意点
+
+- **オプショナル属性**: 既存ユーザー・既存接続レコードは slackUserId 未設定。逆引きで見つからない場合は安全にスキップ（エラーにしない）。
+- **GSI 射影**: KEYS_ONLY が最安だが、cognitoSub を直接取りたいので合成キー `slackLookupKey` を PK にして、テーブル本体の PK(`USER#<sub>`) を射影に含める（または cognitoSub 属性を INCLUDE）。実装時に最小射影で確定。
+- **既知の Floci 制限**: GSI 作成は Floci で動くが、EventBridge ルールの一部が CREATE_FAILED になる既知問題あり（本番では正常）。検証は GSI 部分のみ Floci、E2E は実 AWS。
+- **冪等性**: OAuth 再連携時は同じ slackLookupKey で上書き（PutItem）。
+- **プライバシー**: TaskCandidate の requester は引き続き仮名化（BR-05）。slackUserId はユーザー紐付け専用で、タスク本文には残さない。
+
+---
+
+## 実装順序（このPR内）
+
+1. shared 型・インターフェース追加 → ビルド
+2. CDK GSI + 権限（synth で検証）
+3. backend Repository 逆引き + auth コールバック保存 + バグ修正
+4. agent TaskExtractorLambdaHandler 逆引き
+5. 各層テスト追加 → 全テストパス確認
+6. Biome / typecheck / build 確認

--- a/pkgs/agent/src/repositories/DynamoSlackUserLookupRepository.ts
+++ b/pkgs/agent/src/repositories/DynamoSlackUserLookupRepository.ts
@@ -1,0 +1,59 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+/**
+ * Slack identity → Cognito user (cognitoSub) の逆引き専用リポジトリ。
+ *
+ * テーブル: service-connections
+ *   GSI-SlackLookup: PK=slackLookupKey ("<teamId>#<slackUserId>"), KEYS_ONLY
+ *   ヒットしたテーブル PK "USER#<cognitoSub>" から cognitoSub を復元する。
+ *
+ * 連携が解除/未設定なら null を返す（呼び出し元で安全にスキップ）。
+ */
+export class DynamoSlackUserLookupRepository {
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly connectionsTable: string;
+
+  constructor() {
+    const ddbClient = new DynamoDBClient({
+      region: process.env.AWS_REGION ?? "ap-northeast-1",
+    });
+    this.docClient = DynamoDBDocumentClient.from(ddbClient);
+    this.connectionsTable =
+      process.env.DYNAMODB_TABLE_CONNECTIONS ??
+      "saborou-service-connections-dev";
+  }
+
+  /** Slack identity を GSI-SlackLookup の合成パーティションキーに変換する */
+  private buildLookupKey(slackTeamId: string, slackUserId: string): string {
+    return `${slackTeamId}#${slackUserId}`;
+  }
+
+  /**
+   * Slack identity から所有 Cognito ユーザー (cognitoSub) を逆引きする。
+   *
+   * @returns cognitoSub。連携済みユーザーが見つからなければ null。
+   */
+  async findCognitoSubBySlackIdentity(
+    slackTeamId: string,
+    slackUserId: string,
+  ): Promise<string | null> {
+    const result = await this.docClient.send(
+      new QueryCommand({
+        TableName: this.connectionsTable,
+        IndexName: "GSI-SlackLookup",
+        KeyConditionExpression: "slackLookupKey = :k",
+        ExpressionAttributeValues: {
+          ":k": this.buildLookupKey(slackTeamId, slackUserId),
+        },
+        Limit: 1,
+      }),
+    );
+
+    const item = result.Items?.[0];
+    if (!item) return null;
+    const pk = item.PK as string | undefined;
+    // PK 形式: "USER#<cognitoSub>"
+    return pk?.startsWith("USER#") ? pk.slice("USER#".length) : null;
+  }
+}

--- a/pkgs/agent/src/repositories/__tests__/DynamoSlackUserLookupRepository.test.ts
+++ b/pkgs/agent/src/repositories/__tests__/DynamoSlackUserLookupRepository.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * DynamoSlackUserLookupRepository ユニットテスト
+ *
+ * 方針: 実際の DynamoDB 呼び出しを防ぐため
+ * @aws-sdk/lib-dynamodb および @aws-sdk/client-dynamodb をモック化する。
+ */
+
+const mockSend = vi.fn();
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn(() => ({ send: mockSend })),
+}));
+
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mockSend })),
+  },
+  QueryCommand: vi.fn((input: unknown) => ({ input })),
+}));
+
+describe("DynamoSlackUserLookupRepository.findCognitoSubBySlackIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DYNAMODB_TABLE_CONNECTIONS = "connections-test";
+  });
+
+  it("queries GSI-SlackLookup with the composite key and returns cognitoSub", async () => {
+    mockSend.mockResolvedValueOnce({
+      Items: [{ PK: "USER#cognito-abc", SK: "CONN#slack" }],
+    });
+
+    const { DynamoSlackUserLookupRepository } = await import(
+      "../DynamoSlackUserLookupRepository.js"
+    );
+    const repo = new DynamoSlackUserLookupRepository();
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U999");
+
+    expect(sub).toBe("cognito-abc");
+    // GSI と合成キーが正しく使われる
+    const sentCommand = mockSend.mock.calls[0][0] as {
+      input: {
+        IndexName: string;
+        ExpressionAttributeValues: Record<string, string>;
+      };
+    };
+    expect(sentCommand.input.IndexName).toBe("GSI-SlackLookup");
+    expect(sentCommand.input.ExpressionAttributeValues[":k"]).toBe("T999#U999");
+  });
+
+  it("returns null when no item matches (unlinked Slack user)", async () => {
+    mockSend.mockResolvedValueOnce({ Items: [] });
+
+    const { DynamoSlackUserLookupRepository } = await import(
+      "../DynamoSlackUserLookupRepository.js"
+    );
+    const repo = new DynamoSlackUserLookupRepository();
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U-unknown");
+
+    expect(sub).toBeNull();
+  });
+
+  it("returns null when Items is undefined", async () => {
+    mockSend.mockResolvedValueOnce({});
+
+    const { DynamoSlackUserLookupRepository } = await import(
+      "../DynamoSlackUserLookupRepository.js"
+    );
+    const repo = new DynamoSlackUserLookupRepository();
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U999");
+
+    expect(sub).toBeNull();
+  });
+
+  it("returns null when PK is not in USER# form", async () => {
+    mockSend.mockResolvedValueOnce({
+      Items: [{ PK: "WEIRD#x", SK: "CONN#slack" }],
+    });
+
+    const { DynamoSlackUserLookupRepository } = await import(
+      "../DynamoSlackUserLookupRepository.js"
+    );
+    const repo = new DynamoSlackUserLookupRepository();
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U999");
+
+    expect(sub).toBeNull();
+  });
+
+  it("falls back to default table name when env var is unset", async () => {
+    // 環境変数を実際に削除する（= undefined 代入だと文字列 "undefined" になり ?? が効かない）
+    // biome-ignore lint/performance/noDelete: env var の真の削除には delete が必要
+    delete process.env.DYNAMODB_TABLE_CONNECTIONS;
+    mockSend.mockResolvedValueOnce({
+      Items: [{ PK: "USER#cognito-abc", SK: "CONN#slack" }],
+    });
+
+    const { DynamoSlackUserLookupRepository } = await import(
+      "../DynamoSlackUserLookupRepository.js"
+    );
+    const repo = new DynamoSlackUserLookupRepository();
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U999");
+
+    expect(sub).toBe("cognito-abc");
+    const sentCommand = mockSend.mock.calls[0][0] as {
+      input: { TableName: string };
+    };
+    expect(sentCommand.input.TableName).toBe("saborou-service-connections-dev");
+  });
+});

--- a/pkgs/agent/src/task-extractor/TaskExtractorLambdaHandler.ts
+++ b/pkgs/agent/src/task-extractor/TaskExtractorLambdaHandler.ts
@@ -1,4 +1,5 @@
 import { BedrockClientAdapter } from "../bedrock/BedrockClientAdapter.js";
+import { DynamoSlackUserLookupRepository } from "../repositories/DynamoSlackUserLookupRepository.js";
 import { DynamoTaskCandidateRepository } from "../repositories/DynamoTaskCandidateRepository.js";
 import {
   EventBridgeSlackEventSchema,
@@ -25,9 +26,10 @@ import { TaskExtractorAgent } from "./TaskExtractorAgent.js";
 
 // モジュールレベルシングルトン (ウォーム呼び出し間で再利用)
 const bedrockClient = new BedrockClientAdapter(
-  process.env["BEDROCK_REGION"] ?? "ap-northeast-1",
+  process.env.BEDROCK_REGION ?? "ap-northeast-1",
 );
 const repository = new DynamoTaskCandidateRepository();
+const slackUserLookup = new DynamoSlackUserLookupRepository();
 
 export const handler = async (event: unknown): Promise<void> => {
   // [1] EventBridge エンベロープを検証 (DP-03: 入力側)
@@ -56,10 +58,26 @@ export const handler = async (event: unknown): Promise<void> => {
     return;
   }
 
+  // Slack identity (teamId + Slack user) から所有 Cognito ユーザーを逆引きする。
+  // 連携していない Slack ユーザーのメッセージはスキップ（こちらの管理対象外）。
+  const cognitoSub = await slackUserLookup.findCognitoSubBySlackIdentity(
+    detail.teamId,
+    rawEvent.user,
+  );
+  if (!cognitoSub) {
+    logInfo({
+      action: "skipped_unlinked_slack_user",
+      teamId: detail.teamId,
+    });
+    return;
+  }
+
   // EventBridge エンベロープ → ドメイン型に変換
+  // userId は Cognito sub（逆引き結果）。message.userId は Slack user ID
+  // （TaskExtractorAgent が依頼者の仮名化に使用）。
   const payload: SlackEventPayload = {
     source: "slack",
-    userId: rawEvent.user,
+    userId: cognitoSub,
     message: {
       text: rawEvent.text,
       channelId: rawEvent.channel,

--- a/pkgs/agent/src/task-extractor/__tests__/TaskExtractorLambdaHandler.test.ts
+++ b/pkgs/agent/src/task-extractor/__tests__/TaskExtractorLambdaHandler.test.ts
@@ -15,10 +15,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockConverse = vi.fn();
 const mockCreate = vi.fn();
+const mockFindCognitoSub = vi.fn();
 
 vi.mock("../../bedrock/BedrockClientAdapter.js", () => ({
   BedrockClientAdapter: vi.fn(() => ({
     converse: mockConverse,
+  })),
+}));
+
+vi.mock("../../repositories/DynamoSlackUserLookupRepository.js", () => ({
+  DynamoSlackUserLookupRepository: vi.fn(() => ({
+    findCognitoSubBySlackIdentity: mockFindCognitoSub,
   })),
 }));
 
@@ -83,15 +90,21 @@ function makeToolUseResponse(
   };
 }
 
+// 実際の Lambda が受け取る EventBridge エンベロープ形式
 const validEvent = {
-  source: "slack",
-  userId: "cognito-user-abc",
-  message: {
-    text: "月曜までに資料を作っておいてください。",
-    channelId: "C12345",
-    messageTs: "1234567890.123456",
+  source: "saborou.webhook",
+  "detail-type": "SlackEvent",
+  detail: {
+    event: {
+      type: "message",
+      text: "月曜までに資料を作っておいてください。",
+      user: "U99999",
+      channel: "C12345",
+      ts: "1234567890.123456",
+      team: "T12345",
+    },
     teamId: "T12345",
-    userId: "U99999",
+    receivedAt: "2026-05-23T00:00:00.000Z",
   },
 };
 
@@ -102,8 +115,10 @@ const validEvent = {
 describe("TaskExtractorLambdaHandler", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    process.env["PSEUDONYMIZE_SALT"] = "test-salt-1234567";
-    process.env["BEDROCK_REGION"] = "ap-northeast-1";
+    process.env.PSEUDONYMIZE_SALT = "test-salt-1234567";
+    process.env.BEDROCK_REGION = "ap-northeast-1";
+    // デフォルト: Slack identity は連携済みユーザーに解決される
+    mockFindCognitoSub.mockResolvedValue("cognito-user-abc");
   });
 
   it("processes a valid task event without throwing", async () => {
@@ -112,6 +127,44 @@ describe("TaskExtractorLambdaHandler", () => {
     const { handler } = await import("../TaskExtractorLambdaHandler.js");
     await expect(handler(validEvent)).resolves.toBeUndefined();
     expect(mockConverse).toHaveBeenCalledOnce();
+    // teamId + Slack user で逆引きが行われる
+    expect(mockFindCognitoSub).toHaveBeenCalledWith("T12345", "U99999");
+  });
+
+  it("includes threadTs when the Slack event has thread_ts", async () => {
+    mockConverse.mockResolvedValueOnce(makeToolUseResponse());
+
+    const threadedEvent = {
+      source: "saborou.webhook",
+      "detail-type": "SlackEvent",
+      detail: {
+        event: {
+          type: "message",
+          text: "スレッド内の依頼です。",
+          user: "U99999",
+          channel: "C12345",
+          ts: "1234567890.123456",
+          thread_ts: "1234567880.000000",
+          team: "T12345",
+        },
+        teamId: "T12345",
+        receivedAt: "2026-05-23T00:00:00.000Z",
+      },
+    };
+
+    const { handler } = await import("../TaskExtractorLambdaHandler.js");
+    await expect(handler(threadedEvent)).resolves.toBeUndefined();
+    expect(mockConverse).toHaveBeenCalledOnce();
+  });
+
+  it("skips when the Slack user is not linked to any Cognito user", async () => {
+    mockFindCognitoSub.mockResolvedValueOnce(null);
+
+    const { handler } = await import("../TaskExtractorLambdaHandler.js");
+    await expect(handler(validEvent)).resolves.toBeUndefined();
+    // 逆引き失敗 → Bedrock も永続化も呼ばれない
+    expect(mockConverse).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it("returns without error for invalid EventBridge payload (no DLQ)", async () => {
@@ -156,6 +209,7 @@ describe("TaskExtractorLambdaHandler", () => {
   });
 
   it("uses default BEDROCK_REGION when env var is missing", async () => {
+    // biome-ignore lint/performance/noDelete: env var の真の削除には delete が必要
     delete process.env.BEDROCK_REGION;
     vi.resetModules();
 
@@ -169,5 +223,55 @@ describe("TaskExtractorLambdaHandler", () => {
     await expect(handler(validEvent)).resolves.toBeUndefined();
 
     expect(BedrockCtor).toHaveBeenCalledWith("ap-northeast-1");
+  });
+
+  it("skips bot/subtype messages (no lookup, no Bedrock)", async () => {
+    const botEvent = {
+      source: "saborou.webhook",
+      "detail-type": "SlackEvent",
+      detail: {
+        event: {
+          type: "message",
+          subtype: "bot_message",
+          bot_id: "B123",
+          text: "自動投稿",
+          user: "U99999",
+          channel: "C12345",
+          ts: "1234567890.123456",
+          team: "T12345",
+        },
+        teamId: "T12345",
+        receivedAt: "2026-05-23T00:00:00.000Z",
+      },
+    };
+
+    const { handler } = await import("../TaskExtractorLambdaHandler.js");
+    await expect(handler(botEvent)).resolves.toBeUndefined();
+    expect(mockFindCognitoSub).not.toHaveBeenCalled();
+    expect(mockConverse).not.toHaveBeenCalled();
+  });
+
+  it("skips messages with incomplete fields (missing text)", async () => {
+    const incompleteEvent = {
+      source: "saborou.webhook",
+      "detail-type": "SlackEvent",
+      detail: {
+        event: {
+          type: "message",
+          text: "",
+          user: "U99999",
+          channel: "C12345",
+          ts: "1234567890.123456",
+          team: "T12345",
+        },
+        teamId: "T12345",
+        receivedAt: "2026-05-23T00:00:00.000Z",
+      },
+    };
+
+    const { handler } = await import("../TaskExtractorLambdaHandler.js");
+    await expect(handler(incompleteEvent)).resolves.toBeUndefined();
+    expect(mockFindCognitoSub).not.toHaveBeenCalled();
+    expect(mockConverse).not.toHaveBeenCalled();
   });
 });

--- a/pkgs/backend/src/__tests__/repositories/DynamoServiceConnectionRepository.test.ts
+++ b/pkgs/backend/src/__tests__/repositories/DynamoServiceConnectionRepository.test.ts
@@ -58,7 +58,7 @@ describe("DynamoServiceConnectionRepository.findByUserAndService", () => {
 
     const conn = await repo.findByUserAndService("user1", "slack");
     expect(conn).not.toBeNull();
-    expect(conn!.service).toBe("slack");
+    expect(conn?.service).toBe("slack");
   });
 
   it("returns null when not found", async () => {
@@ -100,6 +100,74 @@ describe("DynamoServiceConnectionRepository.saveForUser", () => {
     });
 
     expect(saved.connectedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("DynamoServiceConnectionRepository.saveForUser — slack identity", () => {
+  it("derives slackLookupKey when both slackTeamId and slackUserId are present", async () => {
+    let captured: { Item?: Record<string, unknown> } = {};
+    const client = mockClient((command: unknown) => {
+      captured = (command as { input: typeof captured }).input;
+      return {};
+    });
+    const repo = new DynamoServiceConnectionRepository(client, TABLE);
+
+    const saved = await repo.saveForUser("user1", {
+      service: "slack",
+      status: "connected",
+      secretArn: "arn:test:secret",
+      slackUserId: "U999",
+      slackTeamId: "T999",
+      expiresAt: null,
+    });
+
+    expect(saved.slackLookupKey).toBe("T999#U999");
+    // marshall された Item にも slackLookupKey が含まれる
+    expect(captured.Item?.slackLookupKey).toEqual({ S: "T999#U999" });
+  });
+
+  it("does not set slackLookupKey when slack identity is absent", async () => {
+    const client = mockClient(() => ({}));
+    const repo = new DynamoServiceConnectionRepository(client, TABLE);
+
+    const saved = await repo.saveForUser("user1", {
+      service: "slack",
+      status: "connected",
+      secretArn: "arn:test:secret",
+      expiresAt: null,
+    });
+
+    expect(saved.slackLookupKey).toBeUndefined();
+  });
+});
+
+describe("DynamoServiceConnectionRepository.findCognitoSubBySlackIdentity", () => {
+  it("returns cognitoSub from GSI lookup hit", async () => {
+    const client = mockClient(() => ({
+      Items: [{ PK: { S: "USER#cognito-abc" }, SK: { S: "CONN#slack" } }],
+    }));
+    const repo = new DynamoServiceConnectionRepository(client, TABLE);
+
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U999");
+    expect(sub).toBe("cognito-abc");
+  });
+
+  it("returns null when no item matches", async () => {
+    const client = mockClient(() => ({ Items: [] }));
+    const repo = new DynamoServiceConnectionRepository(client, TABLE);
+
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U-unknown");
+    expect(sub).toBeNull();
+  });
+
+  it("returns null when PK is not in USER# form", async () => {
+    const client = mockClient(() => ({
+      Items: [{ PK: { S: "WEIRD#x" }, SK: { S: "CONN#slack" } }],
+    }));
+    const repo = new DynamoServiceConnectionRepository(client, TABLE);
+
+    const sub = await repo.findCognitoSubBySlackIdentity("T999", "U999");
+    expect(sub).toBeNull();
   });
 });
 

--- a/pkgs/backend/src/__tests__/routes/auth-callback.test.ts
+++ b/pkgs/backend/src/__tests__/routes/auth-callback.test.ts
@@ -10,7 +10,7 @@
  * 全ての外部呼び出しはモック — AWS 課金なし、ネットワーク呼び出しなし。
  */
 
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { errorHandler } from "../../middleware/error-handler.js";
@@ -64,7 +64,13 @@ vi.stubGlobal("fetch", mockFetch);
 
 const MOCK_USER_ID = "user-callback-test";
 
-async function buildTestApp(connRepo: Record<string, unknown> = {}) {
+async function buildTestApp(
+  connRepo: Record<string, unknown> = {},
+  userRepo: Record<string, unknown> = {
+    findById: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn().mockResolvedValue({}),
+  },
+) {
   const { createAuthRoute } = await import("../../routes/auth.js");
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
@@ -79,6 +85,7 @@ async function buildTestApp(connRepo: Record<string, unknown> = {}) {
     "/auth",
     createAuthRoute(
       connRepo as unknown as Parameters<typeof createAuthRoute>[0],
+      userRepo as unknown as Parameters<typeof createAuthRoute>[1],
     ),
   );
   app.onError(errorHandler);
@@ -282,6 +289,89 @@ describe("GET /auth/slack/callback — success path (new secret)", () => {
         secretArn: "saborou/slack-bot-token/user-callback-test",
       }),
     );
+  });
+
+  it("saves slack identity to connection and links it to the Cognito user (authed_user present)", async () => {
+    mockGetSlackClientSecret.mockResolvedValue(
+      JSON.stringify({
+        clientId: "slack-client-id",
+        clientSecret: "slack-client-secret",
+      }),
+    );
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        ok: true,
+        access_token: "xoxb-token",
+        team: { id: "T999", name: "LinkedTeam" },
+        authed_user: { id: "U999" },
+      }),
+    });
+    mockSend.mockResolvedValue({
+      ARN: "arn:aws:secretsmanager:ap-northeast-1:123:secret/token",
+    });
+
+    const saveForUser = vi.fn().mockResolvedValue({});
+    const existingUser = {
+      PK: `USER#${MOCK_USER_ID}`,
+      SK: "PROFILE",
+      cognitoSub: MOCK_USER_ID,
+      email: "u@example.com",
+      name: "U",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    };
+    const findById = vi.fn().mockResolvedValue(existingUser);
+    const upsert = vi.fn().mockResolvedValue(existingUser);
+
+    const app = await buildTestApp({ saveForUser }, { findById, upsert });
+
+    const res = await app.request(
+      `/auth/slack/callback?code=test-code&state=${validState}`,
+    );
+
+    expect(res.status).toBe(302);
+    // connection に slack identity が保存される
+    expect(saveForUser).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ slackUserId: "U999", slackTeamId: "T999" }),
+    );
+    // User プロフィールにも slack identity が紐付けられる
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ slackUserId: "U999", slackTeamId: "T999" }),
+    );
+  });
+
+  it("does not link slack identity to user when authed_user is absent", async () => {
+    mockGetSlackClientSecret.mockResolvedValue(
+      JSON.stringify({
+        clientId: "slack-client-id",
+        clientSecret: "slack-client-secret",
+      }),
+    );
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        ok: true,
+        access_token: "xoxb-token",
+        team: { id: "T123", name: "Team" },
+        // authed_user なし
+      }),
+    });
+    mockSend.mockResolvedValue({
+      ARN: "arn:aws:secretsmanager:ap-northeast-1:123:secret/token",
+    });
+
+    const saveForUser = vi.fn().mockResolvedValue({});
+    const findById = vi.fn().mockResolvedValue(null);
+    const upsert = vi.fn().mockResolvedValue({});
+    const app = await buildTestApp({ saveForUser }, { findById, upsert });
+
+    const res = await app.request(
+      `/auth/slack/callback?code=test-code&state=${validState}`,
+    );
+
+    expect(res.status).toBe(302);
+    // authed_user が無いので User の紐付けは行われない
+    expect(upsert).not.toHaveBeenCalled();
   });
 
   it("rethrows unexpected error from CreateSecretCommand (not ResourceExistsException)", async () => {

--- a/pkgs/backend/src/__tests__/routes/auth.test.ts
+++ b/pkgs/backend/src/__tests__/routes/auth.test.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import { errorHandler } from "../../middleware/error-handler.js";
 import type { DynamoServiceConnectionRepository } from "../../repositories/DynamoServiceConnectionRepository.js";
+import type { DynamoUserRepository } from "../../repositories/DynamoUserRepository.js";
 import { createAuthRoute } from "../../routes/auth.js";
 import type { AppEnv } from "../../types.js";
 
@@ -32,7 +33,10 @@ vi.mock("../../config/env.js", () => ({
 
 const MOCK_USER_ID = "user-auth-test";
 
-function buildTestApp(connRepo: Partial<DynamoServiceConnectionRepository>) {
+function buildTestApp(
+  connRepo: Partial<DynamoServiceConnectionRepository>,
+  userRepo: Partial<DynamoUserRepository> = {},
+) {
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
     (c as unknown as { env: unknown }).env = {
@@ -44,7 +48,10 @@ function buildTestApp(connRepo: Partial<DynamoServiceConnectionRepository>) {
   });
   app.route(
     "/auth",
-    createAuthRoute(connRepo as DynamoServiceConnectionRepository),
+    createAuthRoute(
+      connRepo as DynamoServiceConnectionRepository,
+      userRepo as DynamoUserRepository,
+    ),
   );
   app.onError(errorHandler);
   return app;
@@ -67,7 +74,10 @@ describe("GET /auth/slack", () => {
     // Do NOT inject requestContext → authMiddleware throws 401
     app.route(
       "/auth",
-      createAuthRoute({} as DynamoServiceConnectionRepository),
+      createAuthRoute(
+        {} as DynamoServiceConnectionRepository,
+        {} as DynamoUserRepository,
+      ),
     );
     app.onError(errorHandler);
 

--- a/pkgs/backend/src/index.ts
+++ b/pkgs/backend/src/index.ts
@@ -53,7 +53,7 @@ import { createUsersRoute } from "./routes/users.js";
 
 // DynamoDB クライアントを初期化 (全リポジトリで共有)
 const dynamoClient = new DynamoDBClient({
-  region: process.env["AWS_REGION"] ?? "ap-northeast-1",
+  region: process.env.AWS_REGION ?? "ap-northeast-1",
 });
 
 // リポジトリを初期化
@@ -107,7 +107,7 @@ export function createApp() {
 
   // /api/* — フロントエンドの apiClient が期待するプレフィックス
   app.route("/api/users", createUsersRoute(userRepository));
-  app.route("/api/auth", createAuthRoute(connectionRepository));
+  app.route("/api/auth", createAuthRoute(connectionRepository, userRepository));
   app.route(
     "/api/tasks",
     createTasksRoute(taskRepository, candidateRepository),

--- a/pkgs/backend/src/repositories/DynamoServiceConnectionRepository.ts
+++ b/pkgs/backend/src/repositories/DynamoServiceConnectionRepository.ts
@@ -6,7 +6,16 @@
  * - GetItem PK=USER#<userId> SK=CONN#<service> — findByUserAndService
  * - PutItem — save
  * - UpdateItem status=disconnected — disconnect
+ * - Query GSI-SlackLookup PK=<teamId>#<slackUserId> — findCognitoSubBySlackIdentity
  */
+
+/** Slack identity を GSI-SlackLookup の合成パーティションキーに変換する */
+export function buildSlackLookupKey(
+  slackTeamId: string,
+  slackUserId: string,
+): string {
+  return `${slackTeamId}#${slackUserId}`;
+}
 
 import {
   type DynamoDBClient,
@@ -73,12 +82,23 @@ export class DynamoServiceConnectionRepository
    */
   async saveForUser(
     userId: string,
-    connection: Omit<ServiceConnection, "PK" | "SK">,
+    // connectedAt は省略可能（省略時は現在時刻で補完する）
+    connection: Omit<ServiceConnection, "PK" | "SK" | "connectedAt"> & {
+      connectedAt?: string;
+    },
   ): Promise<ServiceConnection> {
+    // Slack identity が揃っていれば GSI-SlackLookup 用の合成キーを導出する。
+    // 既存呼び出し（slackUserId/slackTeamId 未指定）との互換のため、揃った場合のみ付与。
+    const slackLookupKey =
+      connection.slackTeamId && connection.slackUserId
+        ? buildSlackLookupKey(connection.slackTeamId, connection.slackUserId)
+        : connection.slackLookupKey;
+
     const item: ServiceConnection = {
       PK: `USER#${userId}`,
       SK: `CONN#${connection.service}`,
       ...connection,
+      ...(slackLookupKey ? { slackLookupKey } : {}),
       connectedAt: connection.connectedAt ?? toIsoString(new Date()),
     };
 
@@ -90,6 +110,35 @@ export class DynamoServiceConnectionRepository
     );
 
     return item;
+  }
+
+  /**
+   * Slack identity から所有 Cognito ユーザー (cognitoSub) を逆引きする。
+   * GSI-SlackLookup (PK=slackLookupKey, KEYS_ONLY) を引き、ヒットした
+   * テーブル PK "USER#<cognitoSub>" から cognitoSub を復元する。
+   *
+   * @returns cognitoSub。連携済みユーザーが見つからなければ null。
+   */
+  async findCognitoSubBySlackIdentity(
+    slackTeamId: string,
+    slackUserId: string,
+  ): Promise<string | null> {
+    const lookupKey = buildSlackLookupKey(slackTeamId, slackUserId);
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        IndexName: "GSI-SlackLookup",
+        KeyConditionExpression: "slackLookupKey = :k",
+        ExpressionAttributeValues: marshall({ ":k": lookupKey }),
+        Limit: 1,
+      }),
+    );
+
+    const item = result.Items?.[0];
+    if (!item) return null;
+    const { PK } = unmarshall(item) as { PK: string };
+    // PK 形式: "USER#<cognitoSub>"
+    return PK.startsWith("USER#") ? PK.slice("USER#".length) : null;
   }
 
   async disconnect(userId: string, service: ServiceType): Promise<void> {

--- a/pkgs/backend/src/routes/auth.ts
+++ b/pkgs/backend/src/routes/auth.ts
@@ -14,18 +14,19 @@
  * 5. トークンを Secrets Manager に保存し、ARN を ServiceConnections DynamoDB に登録
  */
 
+import { createHmac, timingSafeEqual } from "node:crypto";
 import {
   CreateSecretCommand,
   SecretsManagerClient,
   UpdateSecretCommand,
 } from "@aws-sdk/client-secrets-manager";
 import { toIsoString } from "@saboru/shared";
-import { createHmac, timingSafeEqual } from "crypto";
 import { Hono } from "hono";
 import { env } from "../config/env.js";
 import { getSlackClientSecret } from "../config/secrets.js";
 import { authMiddleware } from "../middleware/auth.js";
 import type { DynamoServiceConnectionRepository } from "../repositories/DynamoServiceConnectionRepository.js";
+import type { DynamoUserRepository } from "../repositories/DynamoUserRepository.js";
 import type { AppEnv } from "../types.js";
 
 const SLACK_OAUTH_SCOPES = [
@@ -40,7 +41,7 @@ const SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize";
 const SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
 
 const smClient = new SecretsManagerClient({
-  region: process.env["AWS_REGION"] ?? "ap-northeast-1",
+  region: process.env.AWS_REGION ?? "ap-northeast-1",
 });
 
 function signState(payload: string, secret: string): string {
@@ -74,6 +75,7 @@ function verifyState(
 
 export function createAuthRoute(
   connectionRepository: DynamoServiceConnectionRepository,
+  userRepository: DynamoUserRepository,
 ): Hono<AppEnv> {
   const auth = new Hono<AppEnv>();
 
@@ -84,9 +86,10 @@ export function createAuthRoute(
    */
   auth.get("/slack", authMiddleware, (c) => {
     const userId = c.get("userId");
-    const clientId = env.COGNITO_CLIENT_ID; // 環境変数から取得する Slack クライアント ID
-    // 注: 本番環境では SLACK_CLIENT_ID を専用の環境変数にするべき。
-    // この実装ではコールバック時に Secrets Manager から取得する。
+    // Slack OAuth 開始用の client_id は専用の環境変数 SLACK_CLIENT_ID から取得する。
+    // （以前は誤って COGNITO_CLIENT_ID を参照する死にコードがあったため整理した。
+    //  コールバック時の token 交換は Secrets Manager の client_id/secret を使う。）
+    const slackClientId = process.env.SLACK_CLIENT_ID ?? "";
 
     const redirectUri = `${c.req.url.replace("/auth/slack", "/auth/slack/callback")}`;
 
@@ -100,7 +103,7 @@ export function createAuthRoute(
     );
 
     const params = new URLSearchParams({
-      client_id: process.env.SLACK_CLIENT_ID ?? "",
+      client_id: slackClientId,
       scope: SLACK_OAUTH_SCOPES,
       redirect_uri: redirectUri,
       state,
@@ -183,6 +186,8 @@ export function createAuthRoute(
       ok: boolean;
       access_token?: string;
       team?: { id: string; name: string };
+      // OAuth v2 はワークスペースにインストールした Slack ユーザーを authed_user で返す
+      authed_user?: { id: string };
       error?: string;
     };
 
@@ -226,14 +231,34 @@ export function createAuthRoute(
       }
     }
 
-    // Save connection record to DynamoDB
+    // Slack identity（ワークスペース・ユーザー）を取得して紐付けに使う
+    const slackTeamId = tokenData.team?.id;
+    const slackUserId = tokenData.authed_user?.id;
+
+    // Save connection record to DynamoDB（slack identity 付き → GSI-SlackLookup 用）
     await connectionRepository.saveForUser(userId, {
       service: "slack",
       status: "connected",
       secretArn,
+      ...(slackUserId ? { slackUserId } : {}),
+      ...(slackTeamId ? { slackTeamId } : {}),
       connectedAt: toIsoString(new Date()),
       expiresAt: null,
     });
+
+    // Cognito ユーザーのプロフィールにも Slack identity を保存する。
+    // これにより受信 Slack イベントを Cognito ユーザーに逆引きできる。
+    if (slackUserId && slackTeamId) {
+      const existing = await userRepository.findById(userId);
+      if (existing) {
+        await userRepository.upsert({
+          ...existing,
+          slackUserId,
+          slackTeamId,
+          updatedAt: toIsoString(new Date()),
+        });
+      }
+    }
 
     // Redirect to frontend with success
     return c.redirect(

--- a/pkgs/cdk/lib/stacks/agent-stack.ts
+++ b/pkgs/cdk/lib/stacks/agent-stack.ts
@@ -99,6 +99,8 @@ export class SaborouAgentStack extends cdk.Stack {
         DYNAMODB_TABLE_TASK_CANDIDATES:
           props.data.tables.taskCandidates.tableName,
         DYNAMODB_TABLE_TASKS: props.data.tables.tasks.tableName,
+        // Slack identity → Cognito user 逆引き用（GSI-SlackLookup を引く）
+        DYNAMODB_TABLE_CONNECTIONS: props.data.tables.connections.tableName,
         BEDROCK_REGION: "ap-northeast-1",
         SLACK_TOKEN_SECRET_NAME:
           props.data.secrets.slackClientSecret.secretName,
@@ -121,6 +123,8 @@ export class SaborouAgentStack extends cdk.Stack {
     taskExtractorFn.addToRolePolicy(marketplacePolicy);
     props.data.tables.taskCandidates.grantReadWriteData(taskExtractorFn);
     props.data.tables.tasks.grantReadData(taskExtractorFn);
+    // Slack identity → Cognito user 逆引き（GSI-SlackLookup を含む読み取り）
+    props.data.tables.connections.grantReadData(taskExtractorFn);
     props.data.secrets.slackClientSecret.grantRead(taskExtractorFn);
 
     // --- SaboriProposer DLQ ---

--- a/pkgs/cdk/lib/stacks/data-stack.ts
+++ b/pkgs/cdk/lib/stacks/data-stack.ts
@@ -1,8 +1,8 @@
 import * as cdk from "aws-cdk-lib";
-import * as cr from "aws-cdk-lib/custom-resources";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import * as cr from "aws-cdk-lib/custom-resources";
 import { NagSuppressions } from "cdk-nag";
 import type { Construct } from "constructs";
 
@@ -80,6 +80,17 @@ export class SaborouDataStack extends cdk.Stack {
     });
 
     // --- GSI ---
+    // connections: Slack identity (<teamId>#<slackUserId>) から所有 Cognito ユーザーを逆引きする。
+    // KEYS_ONLY で十分（テーブル PK "USER#<cognitoSub>" が射影されるため cognitoSub を復元できる）。
+    connections.addGlobalSecondaryIndex({
+      indexName: "GSI-SlackLookup",
+      partitionKey: {
+        name: "slackLookupKey",
+        type: dynamodb.AttributeType.STRING,
+      },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
+    });
+
     taskCandidates.addGlobalSecondaryIndex({
       indexName: "GSI-UserCreatedAt",
       partitionKey: { name: "userId", type: dynamodb.AttributeType.STRING },

--- a/pkgs/shared/src/repositories/interface/IServiceConnectionRepository.ts
+++ b/pkgs/shared/src/repositories/interface/IServiceConnectionRepository.ts
@@ -7,6 +7,8 @@ import type { ServiceConnection, ServiceType } from "../../types";
  * - Query PK=USER#<userId> SK begins_with CONN# — Connection list
  * - PutItem — Save connection info at Slack OAuth callback
  * - UpdateItem — Update status=disconnected on disconnect
+ * - Query GSI-SlackLookup PK=<teamId>#<slackUserId> — Resolve Cognito user
+ *   from an inbound Slack identity
  */
 export interface IServiceConnectionRepository {
   /**
@@ -30,4 +32,16 @@ export interface IServiceConnectionRepository {
    * DynamoDB: UpdateItem PK=USER#<userId> SK=CONN#<service>
    */
   disconnect(userId: string, service: ServiceType): Promise<void>;
+
+  /**
+   * Resolve the owning Cognito user (cognitoSub) from a Slack identity.
+   * DynamoDB: Query GSI-SlackLookup PK=<teamId>#<slackUserId>
+   * Used by the TaskExtractor to map inbound Slack events to a Cognito user.
+   *
+   * @returns cognitoSub, or null if no connected user matches
+   */
+  findCognitoSubBySlackIdentity(
+    slackTeamId: string,
+    slackUserId: string,
+  ): Promise<string | null>;
 }

--- a/pkgs/shared/src/types/service-connection.ts
+++ b/pkgs/shared/src/types/service-connection.ts
@@ -24,6 +24,22 @@ export interface ServiceConnection {
    * Token itself is not stored here — managed by Secrets Manager
    */
   secretArn: string;
+  /**
+   * Slack user ID captured at OAuth time (e.g., "U12345678").
+   * Only present for Slack connections.
+   */
+  slackUserId?: string;
+  /**
+   * Slack workspace (team) ID captured at OAuth time (e.g., "T12345678").
+   * Only present for Slack connections.
+   */
+  slackTeamId?: string;
+  /**
+   * Composite lookup key "<slackTeamId>#<slackUserId>" used as the partition
+   * key of GSI-SlackLookup. Lets inbound Slack events resolve back to the
+   * owning Cognito user. Only present for Slack connections.
+   */
+  slackLookupKey?: string;
   /** Connection datetime (ISO 8601) */
   connectedAt: string;
   /** Token expiration (ISO 8601 / null: no expiration) */

--- a/pkgs/shared/src/types/user.ts
+++ b/pkgs/shared/src/types/user.ts
@@ -15,6 +15,17 @@ export interface User {
   email: string;
   /** Display name */
   name: string;
+  /**
+   * Linked Slack user ID (e.g., "U12345678").
+   * Set when the user completes Slack OAuth. Used to map inbound Slack
+   * events back to this Cognito user.
+   */
+  slackUserId?: string;
+  /**
+   * Linked Slack workspace (team) ID (e.g., "T12345678").
+   * Combined with slackUserId to uniquely identify the Slack identity.
+   */
+  slackTeamId?: string;
   /** Creation datetime (ISO 8601) */
   createdAt: string;
   /** Update datetime (ISO 8601) */


### PR DESCRIPTION
## 概要

「Slack と Cognito のユーザーIDのミスマッチ」を解消します。機能改修バックログの **タスクB**（A→**B**→C→D→E→F→G の2番目）です。

> ⚠️ このPRは [#24（タスクA）](https://github.com/mashharuki/AWS-SummitHackathon-2026/pull/24) とは独立しており、main から分岐しています。触る領域が重ならないため並行してマージ可能です。

## 根本原因

`pkgs/agent/src/task-extractor/TaskExtractorLambdaHandler.ts` が **Slack の user ID を Cognito userId として誤って代入**していました。

```
Slack message (event.user, team_id)
  → webhook → EventBridge (teamId のみ)
  → TaskExtractor: payload.userId = rawEvent.user  ← Slack ID を Cognito ID として使用（バグ）
  → TaskCandidate が誤った userId で保存 → ユーザーが自分のタスクを取得できない
```

Slack イベントは `teamId` と Slack `user` ID しか持たないのに、それを Cognito ユーザーに紐付ける仕組みが存在しませんでした。

## 解決：Slack identity → Cognito ユーザーの逆引き

OAuth 連携時に「どの Cognito ユーザーが、どの Slack team の、どの Slack user か」を保存し、受信イベントを逆引きできるようにしました。

| レイヤ | 変更 |
|---|---|
| **shared** | `User`/`ServiceConnection` 型に `slackUserId`/`slackTeamId`(+`slackLookupKey`) を追加。`IServiceConnectionRepository` に `findCognitoSubBySlackIdentity` を追加 |
| **cdk** | connections テーブルに **GSI-SlackLookup**（PK=`slackLookupKey`=`<teamId>#<slackUserId>`, KEYS_ONLY）を追加。TaskExtractor Lambda に connections の Read 権限・テーブル名 env を付与 |
| **backend** | `DynamoServiceConnectionRepository` に `slackLookupKey` 書き込み＋逆引きを実装。OAuth コールバックで `authed_user.id`/`team.id` を取得し User/ServiceConnection に保存。**Slack OAuth 開始時の `client_id` 誤用バグ（`COGNITO_CLIENT_ID` 死にコード）も整理** |
| **agent** | `DynamoSlackUserLookupRepository` を新規追加。`TaskExtractorLambdaHandler` で `(teamId + Slack user)` → cognitoSub を逆引きして `payload.userId` に設定。**未連携ユーザーのメッセージは安全にスキップ** |

## 設計判断

- **オプショナル属性**：既存ユーザー・接続レコードは `slackUserId` 未設定。逆引きで見つからなければエラーにせずスキップ。
- **GSI 射影 KEYS_ONLY**：テーブル PK `USER#<cognitoSub>` が射影されるため cognitoSub を復元可能（最小コスト）。
- **冪等性**：OAuth 再連携は同じ `slackLookupKey` で上書き（PutItem）。
- **プライバシー維持**：TaskCandidate の requester は引き続き仮名化（BR-05）。slackUserId は紐付け専用。

設計詳細：`aidlc-docs/construction/slack-cognito-linking/design.md`

## テスト・品質

- ✅ shared **103** / backend **199** / agent **155** 全テストパス（新規多数追加）
- ✅ agent カバレッジ **100% 維持**
- ✅ 型チェック（shared/backend/agent/cdk）通過 / ✅ `cdk synth SaborouAgent-dev` 成功
- Biome エラー総数：変更前 179 → 変更後 168（悪化なし）

## 動作確認

- ローカル：全パッケージのテスト・型チェック・CDK synth で確認
- ⚠️ 実 OAuth フロー（`authed_user` の実取得）と GSI の実クエリは**実 AWS 環境での検証が必要**です。GSI 部分は Floci でも検証可能。ロジックは型・テストで担保済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Slack ↔ Cognito user ID linking mismatch
  * Unlinked Slack users are now safely skipped from processing

* **New Features**
  * Added bidirectional Slack user identity linking with reverse lookup support
  * Enhanced user connection management for Slack integration

* **Documentation**
  * Added comprehensive design documentation for user linking workflows

* **Tests**
  * Expanded test coverage for identity linking and verification scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mashharuki/AWS-SummitHackathon-2026/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->