### PR TITLE
feat(slack): Bot Token化・Slack履歴の遡及タスク化・判定のSlack返信

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -1335,3 +1335,26 @@ aidlc-state.md U-06 セクションも本改訂版に合わせて更新済み（
 **Context**: タスクB実装完了。PR #25 作成済み。
 
 ---
+
+## タスクB マージとタスクC起点準備
+**Timestamp**: 2026-05-23T11:00:00Z
+**User Input**: "Bがコンフリクトが起きているのでそれを確認して、…マージして、その後マージしたmainからCを分岐させるのはどう思いますか"
+**AI Response**: PR #25 の audit.md コンフリクト（タスクA/Bの末尾追記衝突）を時系列順に統合して解決。マージ後の統合テスト（shared 103/backend 202/agent 155/frontend 135 全パス）を確認し PR #25 をマージ（main 8b58edd）。最新 main から `feature/slack-task-list-and-bot-token` を作成。
+**Context**: タスクA・Bマージ済み。タスクC着手。
+
+---
+
+## タスクC: Bot Token化 + Slackからタスク一覧取得 + インタラクティブ返信
+**Timestamp**: 2026-05-23T11:30:00Z
+**User Input**: タスクCスコープ選択 = "全てお願いします"（SlackClient・Bot Token不整合修正・遡及取得API・返信機構・ドキュメント）
+**AI Response**: 事前調査で Bot Token 取得の重大な不整合を発見 — ContextCollector が `SLACK_TOKEN_SECRET_NAME`(=OAuth Client Secret) を参照し、per-user Bot Token(`saborou/slack-bot-token/{userId}`)に届いていなかった。全部を1PRで実装（ブランチ `feature/slack-task-list-and-bot-token`）:
+- agent: SlackClient 新規（conversations.history / chat.postMessage、5sタイムアウト、ok:false エラー化）。ContextCollector を per-user Bot Token 取得に修正（getSlackToken(userId)・Mapキャッシュ・SLACK_BOT_TOKEN_SECRET_PREFIX）。TaskExtractorLambdaHandler を SlackEvent(逆引き)/SlackBackfill(userId直接) 両対応に分岐。events.ts に backfill スキーマ追加。
+- backend: POST /api/slack/sync-messages（履歴遡及→EventBridge backfill publish）と POST /api/slack/notify-task（判定を Slack 投稿）を新規。SLACK_OAUTH_SCOPES に chat:write 追加。
+- CDK: agent/api Lambda に per-user Bot Token(`saborou/slack-bot-token/*`) GetSecretValue 権限・SLACK_BOT_TOKEN_SECRET_PREFIX env を付与。誤った SLACK_TOKEN_SECRET_NAME=clientSecret を廃止。api に EVENT_BUS_NAME(固定名で循環回避)・events:PutEvents 権限を追加。
+- docs: slack-app-setup.md に Bot Token化手順（chat:write・per-user保存・再認可注意）を追記。slack-api-integration.md を新規作成。
+品質確認: shared 103 / backend 212 / agent 169 全テストパス（agent カバレッジ100%維持）。型チェック・CDK synth(Agent/Api)・ビルド OK。Biome エラー総数 変更前168→変更後165（悪化なし）。
+途中、Biome formatter が inline import type を壊しテストが全滅→トップレベル import type に修正（[[feedback-biome-unsafe-nodelete-risk]] に追記）。
+設計詳細は aidlc-docs/construction/slack-task-list-bot-token/design.md。
+**Context**: タスクC実装完了。コミット・PR待ち。
+
+---

--- a/aidlc-docs/construction/slack-task-list-bot-token/design.md
+++ b/aidlc-docs/construction/slack-task-list-bot-token/design.md
@@ -1,0 +1,113 @@
+# タスクC 設計：Bot Token化 + Slackからタスク一覧取得 + インタラクティブ返信
+
+**作成日**: 2026-05-23
+**ブランチ**: `feature/slack-task-list-and-bot-token`
+**スコープ**: 全部（SlackClient実装・Bot Token不整合修正・遡及取得API・返信機構・ドキュメント）
+**前提**: タスクB（slackUserId/slackTeamId 紐付け・GSI-SlackLookup 逆引き）マージ済み
+
+---
+
+## 解決する3つの課題
+
+ユーザー要望:
+1. **StackのBot Token化手順が抜けている** → セットアップ手順とコードの不整合を解消
+2. **Bot Token化できたらもっとインタラクティブなやり取り** → chat.postMessage で Slack へ返信
+3. **Slackからタスク一覧とか取得できる？** → conversations.history で過去メッセージを遡及取得しタスク化／Slackにタスク一覧を投稿
+
+---
+
+## 最重要：Bot Token 取得の不整合（バグ）
+
+### 現状の不整合（実コードで確認）
+
+| 項目 | 場所 | 実態 |
+|---|---|---|
+| Bot Token 保存先 | `auth.ts:207` | `saborou/slack-bot-token/{userId}`（**per-user**） |
+| ContextCollector の取得先 | `ContextCollector.ts:40` | env `SLACK_TOKEN_SECRET_NAME` |
+| その env に CDK が渡す値 | `agent-stack.ts:105-107,166-167` | `slackClientSecret.secretName`（= `/saborou/slack/client-secret-{env}` = **OAuth用 Client Secret**） |
+
+→ ContextCollector は **Bot Token ではなく Client Secret を取得**してしまい、かつ per-user の Bot Token にアクセスできない。Slack API を叩けば確実に失敗する。これが「Bot Token化が抜けている」の技術的核心。
+
+### 修正方針
+
+ContextCollector を **userId（cognitoSub）を受け取って per-user の Bot Token を取得**する形にする:
+- env で受け取るのは「シークレット名のプレフィックス」（`SLACK_BOT_TOKEN_SECRET_PREFIX = saborou/slack-bot-token/`）
+- `getSlackToken(userId)` で `{prefix}{userId}` を解決して取得
+- キャッシュは userId 別（Map）に変更
+- CDK: agent Lambda に `saborou/slack-bot-token/*` への `secretsmanager:GetSecretValue` 権限を付与（per-user シークレットはワイルドカード ARN）。誤って渡していた `SLACK_TOKEN_SECRET_NAME=clientSecret` を廃止
+
+---
+
+## 実装一覧
+
+### 1. shared / SlackClient（新規・最重要）
+- `pkgs/agent/src/slack-client/SlackClient.ts`（新規）
+  - Bot Token を受け取り Slack Web API を叩く薄いラッパー
+  - メソッド: `conversationsHistory({channel, oldest?, limit?})`, `postMessage({channel, text, thread_ts?})`, `usersInfo(user)`（必要に応じ）
+  - `https://slack.com/api/*` を fetch。`ok:false` 時はエラー、レート制限(429)は素直に伝播
+  - タイムアウト（AbortController、既定 5s）
+
+### 2. ContextCollector の Bot Token 取得修正
+- `pkgs/agent/src/context-collector/ContextCollector.ts`
+  - `getSlackToken(userId)` に変更（per-user）。キャッシュを `Map<userId, token>` に
+  - シークレット名は `${SLACK_BOT_TOKEN_SECRET_PREFIX}${userId}`
+  - 後方互換: 既存呼び出し元（SaboriProposer の collectMinimalSlackContext スタブ）も追従
+
+### 3. CDK
+- `agent-stack.ts`:
+  - `SLACK_TOKEN_SECRET_NAME=clientSecret` を廃止し、`SLACK_BOT_TOKEN_SECRET_PREFIX` を設定
+  - per-user Bot Token シーク360レットへの GetSecretValue 権限を追加（`arn:aws:secretsmanager:...:secret:saborou/slack-bot-token/*`）
+- backend Lambda（api-stack）: 遡及取得 API が Bot Token を読むため同様の権限が必要
+
+### 4. backend: 遡及取得 API
+- `pkgs/backend/src/routes/slack.ts`（新規）
+  - `POST /api/slack/sync-messages`（認証必須）
+  - body: `{ channelId, oldest? }`
+  - 認証ユーザーの Bot Token を取得 → SlackClient.conversationsHistory → 各メッセージを EventBridge `SlackEvent` として publish（既存 TaskExtractor パイプ再利用）
+  - 逆引き不要（呼び出し元が認証済み Cognito ユーザー＝userId 確定。EventBridge detail に userId を載せる経路を追加）
+- `index.ts` にルート登録
+
+> 設計判断: 遡及取得は「認証ユーザー自身が自分のチャンネル履歴を同期する」操作なので、Webhook 経由（逆引き必要）とは別に、userId を直接持つ EventBridge イベント（`detailType: SlackBackfill` 等）にする。TaskExtractorLambdaHandler は両方（逆引き要/不要）を扱えるよう分岐。
+
+### 5. インタラクティブ返信（chat.postMessage）
+- サボり提案が完了したら Slack スレッドに返信する経路
+- スコープに `chat:write` を追加（`auth.ts` SLACK_OAUTH_SCOPES）
+- 実装は SaboriProposer 側 or backend エンドポイント。MVP は backend に `POST /api/tasks/:taskId/notify-slack` を置き、提案結果を Slack へ postMessage する薄い実装
+
+### 6. ドキュメント
+- `aidlc-docs/operations/slack-app-setup.md` に Bot Token 化手順を追記:
+  - Bot Token Scopes に `chat:write` 追加
+  - Bot User OAuth Token（xoxb-）の確認手順
+  - `SLACK_BOT_TOKEN_SECRET_PREFIX` 環境変数の説明と CDK 出力との対応
+  - OAuth スコープ変更後は既存連携ユーザーに再認可が必要、の注意
+- `aidlc-docs/operations/slack-api-integration.md`（新規）: SlackClient の使い方・エラー処理・遡及取得/返信フロー図
+
+### 7. テスト
+- SlackClient: conversationsHistory / postMessage の成功・ok:false・タイムアウト
+- ContextCollector: per-user 取得・キャッシュ・env未設定
+- backend slack route: 認証・sync-messages の publish
+- agent TaskExtractor: backfill 経路（userId 直接）の処理
+- 既存テストの追従（ContextCollector シグネチャ変更の波及）
+
+---
+
+## 設計上の留意点
+
+- **既存連携ユーザーの再認可**: `chat:write` 追加で OAuth スコープが変わるため、既存トークンでは chat.postMessage が 403。設定画面に「再連携」導線が必要（本PRではドキュメント注意に留め、UI改善は別途）。
+- **Slack API レート制限**: conversations.history は Tier 3（~50+/min）。遡及取得は limit と oldest で範囲を絞る。
+- **Lambda タイムアウト**: Slack API 呼び出しは AbortController で 5s。TaskExtractor 60s / SaboriProposer 90s と矛盾しない。
+- **冪等性**: 遡及取得で同じ messageTs を重複処理しないよう、TaskCandidate 側の ULID 冪等性（既存 attribute_not_exists）に委ねる。完全な重複排除は MVP スコープ外。
+- **AWS制約**: per-user シークレットのワイルドカード権限は最小権限の範囲（`saborou/slack-bot-token/*` のみ）。
+
+---
+
+## 実装順序（このPR内）
+
+1. SlackClient 実装 + テスト
+2. ContextCollector を per-user Bot Token 取得に修正 + テスト + 既存波及修正
+3. CDK 権限・env 修正（synth 確認）
+4. backend 遡及取得 API + EventBridge backfill 経路 + テスト
+5. agent TaskExtractor の backfill 分岐 + テスト
+6. chat:write スコープ追加 + 返信エンドポイント + テスト
+7. ドキュメント整備（slack-app-setup.md 追記 + slack-api-integration.md 新規）
+8. 全テスト・型・カバレッジ・Biome・CDK synth で品質確認

--- a/aidlc-docs/operations/slack-api-integration.md
+++ b/aidlc-docs/operations/slack-api-integration.md
@@ -1,0 +1,110 @@
+# Slack API 連携ガイド（Bot Token を能動的に使う）
+
+タスクCで追加した「Slack からタスク一覧取得」「インタラクティブ返信」の仕組みをまとめる。
+Webhook 受信（Slack → SABOROU）の設定は [slack-app-setup.md](./slack-app-setup.md) を参照。
+
+---
+
+## 全体像
+
+```
+[遡及取得: Slack 履歴 → タスク化]
+ユーザー（認証済み）
+  │ POST /api/slack/sync-messages { channelId, oldest?, limit? }
+  ▼
+backend (HonoFn)
+  │ getSlackToken(cognitoSub) で per-user Bot Token 取得
+  │ SlackClient.conversationsHistory() で過去メッセージ取得
+  │ bot/subtype/空 を除外
+  │ 各メッセージを EventBridge (SlackBackfill, userId 直接) へ publish
+  ▼
+TaskExtractor Lambda
+  │ SlackBackfill を検知（逆引き不要）→ Bedrock でタスク抽出 → TaskCandidate 保存
+  ▼
+GET /api/tasks/candidates でユーザーが確認・承認
+
+[インタラクティブ返信: 判定 → Slack 投稿]
+ユーザー（認証済み）
+  │ POST /api/slack/notify-task { taskId, channelId, threadTs? }
+  ▼
+backend
+  │ タスク所有者確認 → 最新 Proposal の verdict 取得
+  │ getSlackToken(cognitoSub) → SlackClient.postMessage()
+  ▼
+Slack チャンネル/スレッドにサボロー口調で投稿
+```
+
+---
+
+## SlackClient（`pkgs/agent/src/slack-client/SlackClient.ts`）
+
+Bot Token を受け取る薄いラッパー。
+
+| メソッド | Slack API | 必要スコープ |
+|---|---|---|
+| `conversationsHistory({channel, oldest?, limit?})` | `conversations.history` | `channels:history` 他 |
+| `postMessage({channel, text, thread_ts?})` | `chat.postMessage` | `chat:write` |
+
+- fetch + AbortController で **5 秒タイムアウト**（Lambda タイムアウトとの整合）
+- Slack は HTTP 200 でも `ok:false` を返すため両方を検査し、失敗時は `SlackApiError` を投げる
+- レート制限（HTTP 429）は `SlackApiError("http_429")` として伝播
+
+---
+
+## per-user Bot Token の取得
+
+- OAuth コールバックで `saborou/slack-bot-token/<cognitoSub>` に保存（[slack-app-setup.md](./slack-app-setup.md) STEP 6-2）
+- `getSlackToken(userId)`（`ContextCollector`）が `${SLACK_BOT_TOKEN_SECRET_PREFIX}${userId}` を解決
+- Lambda ウォーム呼び出し時は userId 別にキャッシュ（DP-06）
+
+### 必要な環境変数 / IAM（CDK 設定済み）
+
+| Lambda | env | IAM |
+|---|---|---|
+| api (HonoFn) | `SLACK_BOT_TOKEN_SECRET_PREFIX`, `EVENT_BUS_NAME` | `secretsmanager:GetSecretValue` on `saborou/slack-bot-token/*`, `events:PutEvents` |
+| TaskExtractor | `SLACK_BOT_TOKEN_SECRET_PREFIX`, `DYNAMODB_TABLE_CONNECTIONS` | 同上 GetSecretValue, connections 読み取り |
+| SaboriProposer | `SLACK_BOT_TOKEN_SECRET_PREFIX` | 同上 GetSecretValue |
+
+---
+
+## API リファレンス
+
+### POST /api/slack/sync-messages（認証必須）
+
+Slack チャンネルの過去メッセージを取得し、タスク候補化キューへ投入する。
+
+リクエスト:
+```json
+{ "channelId": "C12345", "oldest": "1700000000.000", "limit": 50 }
+```
+レスポンス:
+```json
+{ "scanned": 20, "queued": 7 }
+```
+- `scanned`: 取得した総メッセージ数
+- `queued`: タスク化キューに投入した数（bot/subtype/空を除外後）
+
+### POST /api/slack/notify-task（認証必須）
+
+タスクの最新サボり判定を Slack に投稿する。
+
+リクエスト:
+```json
+{ "taskId": "01HX...", "channelId": "C12345", "threadTs": "1700000000.000" }
+```
+レスポンス:
+```json
+{ "posted": true, "ts": "1700000123.456", "verdict": "can_saboru" }
+```
+- 他人のタスクを指定すると 404
+- Proposal が無い場合は `borderline` にフォールバック
+
+---
+
+## 注意点
+
+- **スコープ変更後の再認可**: `chat:write` 追加後、既存連携ユーザーは再連携が必要（古い Bot Token には新スコープが無い）。
+- **チャンネルへの Bot 招待**: `conversations.history` / `chat.postMessage` は対象チャンネルに Bot が参加している必要がある（`/invite @SABOROU`）。
+- **レート制限**: `conversations.history` は Tier 3。遡及取得は `oldest` / `limit` で範囲を絞る。
+- **冪等性**: 同一メッセージの重複タスク化は TaskCandidate の ULID 冪等性に委ねる（完全な重複排除は MVP スコープ外）。
+- **プライバシー**: 取り込んだメッセージの依頼者は仮名化（BR-05）。Slack 本文は TaskCandidate 保存後に破棄。

--- a/aidlc-docs/operations/slack-app-setup.md
+++ b/aidlc-docs/operations/slack-app-setup.md
@@ -81,8 +81,11 @@ URL に含まれる App ID（例: `A0XXXXXXXX`）をメモしておく。
 | `im:history` | DM（ダイレクトメッセージ）取得 |
 | `mpim:history` | グループ DM のメッセージ取得 |
 | `users:read` | ユーザーステータス・プロフィール取得（サボり判定に使用） |
+| `chat:write` | サボり判定を Slack スレッドに投稿（インタラクティブ返信 / `POST /api/slack/notify-task`） |
 
 > **注**: これらは `routes/auth.ts` の `SLACK_OAUTH_SCOPES` 定数で定義されているスコープと完全に一致させること。
+>
+> ⚠️ **スコープ変更後の再認可**: 既に Slack 連携済みのユーザーは、スコープを追加しても古い Bot Token のままでは新スコープ（`chat:write` など）が有効にならない。設定画面から **一度連携を解除して再連携**するよう案内すること。
 
 ### 2-2. Redirect URLs を追加
 
@@ -250,11 +253,28 @@ Lambda は `routes/webhooks.ts` 内で `url_verification` タイプを検出し�
 左メニュー **「OAuth & Permissions」** → **「Install to Workspace」** をクリック。  
 権限確認ダイアログで **「許可する」** をクリック。
 
-### 6-2. Bot User OAuth Token を取得
+### 6-2. Bot User OAuth Token の扱い（重要）
 
-インストール後、**「Bot User OAuth Token」** が表示される（`xoxb-` で始まる）。  
-このトークンは後続の Slack API 呼び出しで必要になる場合があるが、  
-**SABOROU では Webhook 受信のみのため現時点では不要**。
+インストール後、**「Bot User OAuth Token」**（`xoxb-` で始まる）が表示される。
+
+**SABOROU は管理者が手動でこのトークンを設定する必要はない。** Bot Token は
+**ユーザーごとに OAuth フロー（`GET /auth/slack` → コールバック）経由で自動取得**され、
+Secrets Manager に **per-user** で保存される:
+
+| 項目 | 値 |
+|------|----|
+| 保存先（per-user） | `saborou/slack-bot-token/<cognitoSub>` |
+| 取得側の環境変数 | `SLACK_BOT_TOKEN_SECRET_PREFIX`（= `saborou/slack-bot-token/`） |
+| 取得実装 | `ContextCollector.getSlackToken(userId)`（agent） |
+| API 呼び出し | `SlackClient`（conversations.history / chat.postMessage） |
+
+> **アーキテクチャ補足**: 旧実装では ContextCollector が単一の Client Secret を
+> 参照しており Bot Token を取得できなかった（不整合）。タスクC でこれを
+> per-user Bot Token 取得に修正済み。CDK は agent / api Lambda に
+> `saborou/slack-bot-token/*` への `secretsmanager:GetSecretValue` 権限を付与している。
+
+つまり、管理者がやるべきことは **OAuth スコープ（STEP 2）と Redirect URL の設定だけ**で、
+実際の Bot Token は各ユーザーが「Slack と連携」したときに自動で保存・利用される。
 
 ### 6-3. App がワークスペースに追加されたことを確認
 

--- a/pkgs/agent/src/context-collector/ContextCollector.ts
+++ b/pkgs/agent/src/context-collector/ContextCollector.ts
@@ -8,10 +8,14 @@ import { logError } from "../utils/logger.js";
  * ContextCollector — エージェントのコンテキスト取得 (DP-06)
  *
  * 責務:
- * - Secrets Manager から Slack OAuth トークンを取得 (ウォームキャッシュ最適化)
+ * - Secrets Manager から per-user の Slack Bot Token を取得 (ウォームキャッシュ最適化)
  * - U-03a (task-extractor) と U-03b (sabori-proposer) の両方で共有
  *
- * DP-06: モジュールスコープキャッシュで Lambda ウォーム呼び出し時の
+ * Bot Token は OAuth コールバックで per-user に保存される:
+ *   シークレット名 = `${SLACK_BOT_TOKEN_SECRET_PREFIX}${cognitoSub}`
+ *   (例: saborou/slack-bot-token/<cognitoSub>)
+ *
+ * DP-06: モジュールスコープの userId 別キャッシュで Lambda ウォーム呼び出し時の
  * Secrets Manager 繰り返し呼び出しを防いでレイテンシーと API コストを削減する。
  *
  * 注意: エラー時にキャッシュを無効化しない — 設定ミスのシークレットでサンダーハードが
@@ -21,26 +25,34 @@ import { logError } from "../utils/logger.js";
 
 // モジュールスコープシングルトン — コールドスタート時のみリセット
 const secretsClient = new SecretsManagerClient({
-  region: process.env["AWS_REGION"] ?? "ap-northeast-1",
+  region: process.env.AWS_REGION ?? "ap-northeast-1",
 });
 
-let cachedSlackToken: string | undefined;
+// userId (cognitoSub) → Bot Token のキャッシュ
+const tokenCache = new Map<string, string>();
+
+const DEFAULT_SECRET_PREFIX = "saborou/slack-bot-token/";
 
 /**
- * Secrets Manager から Slack OAuth トークンを取得する。
- * Lambda ウォーム呼び出し時はキャッシュ値を返す (DP-06)。
+ * per-user の Slack Bot Token を Secrets Manager から取得する。
+ * Lambda ウォーム呼び出し時は userId 別キャッシュ値を返す (DP-06)。
  *
- * @throws SLACK_TOKEN_SECRET_NAME が未設定またはシークレットが空の場合
+ * @param userId Cognito sub。Bot Token シークレットの per-user キー。
+ * @throws userId が空、またはシークレットが空の場合
  */
-export async function getSlackToken(): Promise<string> {
-  if (cachedSlackToken !== undefined) {
-    return cachedSlackToken;
+export async function getSlackToken(userId: string): Promise<string> {
+  if (!userId) {
+    throw new Error("userId is required to resolve the Slack bot token");
   }
 
-  const secretName = process.env["SLACK_TOKEN_SECRET_NAME"];
-  if (!secretName) {
-    throw new Error("SLACK_TOKEN_SECRET_NAME environment variable is required");
+  const cached = tokenCache.get(userId);
+  if (cached !== undefined) {
+    return cached;
   }
+
+  const prefix =
+    process.env.SLACK_BOT_TOKEN_SECRET_PREFIX ?? DEFAULT_SECRET_PREFIX;
+  const secretName = `${prefix}${userId}`;
 
   const response = await secretsClient.send(
     new GetSecretValueCommand({ SecretId: secretName }),
@@ -54,16 +66,16 @@ export async function getSlackToken(): Promise<string> {
     throw new Error(`Secret ${secretName} has no SecretString value`);
   }
 
-  cachedSlackToken = response.SecretString;
-  return cachedSlackToken;
+  tokenCache.set(userId, response.SecretString);
+  return response.SecretString;
 }
 
 /**
- * Reset cached token (test utility / forced refresh)
+ * Reset cached tokens (test utility / forced refresh)
  * Not intended for production use.
  */
 export function resetSlackTokenCache(): void {
-  cachedSlackToken = undefined;
+  tokenCache.clear();
 }
 
 /**
@@ -73,7 +85,7 @@ export function resetSlackTokenCache(): void {
  * to the module-level cached functions above.
  */
 export class ContextCollector {
-  async getSlackToken(): Promise<string> {
-    return getSlackToken();
+  async getSlackToken(userId: string): Promise<string> {
+    return getSlackToken(userId);
   }
 }

--- a/pkgs/agent/src/context-collector/__tests__/ContextCollector.test.ts
+++ b/pkgs/agent/src/context-collector/__tests__/ContextCollector.test.ts
@@ -1,14 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * ContextCollector ユニットテスト (DP-06: Secrets Manager キャッシュ)
+ * ContextCollector ユニットテスト (DP-06: Secrets Manager per-user キャッシュ)
  *
- * 実障の Secrets Manager 呼び出しを防ぐため AWS SDK をモック化する。
+ * 実際の Secrets Manager 呼び出しを防ぐため AWS SDK をモック化する。
  */
-
-// ─────────────────────────────────────────────
-// モジュールモック
-// ─────────────────────────────────────────────
 
 const mockSend = vi.fn();
 
@@ -17,55 +13,81 @@ vi.mock("@aws-sdk/client-secrets-manager", () => ({
   GetSecretValueCommand: vi.fn((input: unknown) => ({ input })),
 }));
 
-// ─────────────────────────────────────────────
-// テスト
-// ─────────────────────────────────────────────
-
-describe("ContextCollector (getSlackToken)", () => {
+describe("ContextCollector (getSlackToken — per-user)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // テスト間でモジュールキャッシュをリセット
     vi.resetModules();
-    process.env["SLACK_TOKEN_SECRET_NAME"] = "saborou-slack-client-secret-test";
+    process.env.SLACK_BOT_TOKEN_SECRET_PREFIX = "saborou/slack-bot-token/";
   });
 
   afterEach(() => {
-    delete process.env["SLACK_TOKEN_SECRET_NAME"];
+    // biome-ignore lint/performance/noDelete: env var の真の削除には delete が必要
+    delete process.env.SLACK_BOT_TOKEN_SECRET_PREFIX;
   });
 
-  it("returns token from Secrets Manager on first call", async () => {
-    mockSend.mockResolvedValueOnce({ SecretString: "xoxb-test-token" });
+  it("resolves the per-user secret name from prefix + userId", async () => {
+    mockSend.mockResolvedValueOnce({ SecretString: "xoxb-user-token" });
 
     const { getSlackToken } = await import("../ContextCollector.js");
-    const token = await getSlackToken();
+    const token = await getSlackToken("cognito-abc");
 
-    expect(token).toBe("xoxb-test-token");
+    expect(token).toBe("xoxb-user-token");
+    // GetSecretValueCommand に prefix+userId が渡る
+    const command = mockSend.mock.calls[0][0] as {
+      input: { SecretId: string };
+    };
+    expect(command.input.SecretId).toBe("saborou/slack-bot-token/cognito-abc");
+  });
+
+  it("falls back to default prefix when env is unset", async () => {
+    // biome-ignore lint/performance/noDelete: env var の真の削除には delete が必要
+    delete process.env.SLACK_BOT_TOKEN_SECRET_PREFIX;
+    mockSend.mockResolvedValueOnce({ SecretString: "xoxb-default" });
+
+    const { getSlackToken } = await import("../ContextCollector.js");
+    await getSlackToken("cognito-xyz");
+
+    const command = mockSend.mock.calls[0][0] as {
+      input: { SecretId: string };
+    };
+    expect(command.input.SecretId).toBe("saborou/slack-bot-token/cognito-xyz");
+  });
+
+  it("returns cached token per user on second call (DP-06 cache hit)", async () => {
+    mockSend.mockResolvedValueOnce({ SecretString: "xoxb-cached" });
+
+    const { getSlackToken } = await import("../ContextCollector.js");
+    const first = await getSlackToken("user1");
+    const second = await getSlackToken("user1");
+
+    expect(first).toBe("xoxb-cached");
+    expect(second).toBe("xoxb-cached");
+    // 同一ユーザーの2回呼び出しでも Secrets Manager は1回のみ
     expect(mockSend).toHaveBeenCalledOnce();
   });
 
-  it("returns cached token on second call (DP-06 cache hit)", async () => {
-    mockSend.mockResolvedValueOnce({ SecretString: "xoxb-test-token-cached" });
+  it("caches independently per user", async () => {
+    mockSend
+      .mockResolvedValueOnce({ SecretString: "token-a" })
+      .mockResolvedValueOnce({ SecretString: "token-b" });
 
     const { getSlackToken } = await import("../ContextCollector.js");
-    const first = await getSlackToken();
-    const second = await getSlackToken();
+    const a = await getSlackToken("userA");
+    const b = await getSlackToken("userB");
 
-    expect(first).toBe("xoxb-test-token-cached");
-    expect(second).toBe("xoxb-test-token-cached");
-    // getSlackToken() を 2 回呼び出しても Secrets Manager は 1 回のみ呼ばれる
-    expect(mockSend).toHaveBeenCalledOnce();
+    expect(a).toBe("token-a");
+    expect(b).toBe("token-b");
+    // 別ユーザーなので2回呼ばれる
+    expect(mockSend).toHaveBeenCalledTimes(2);
   });
 
-  it("throws when SLACK_TOKEN_SECRET_NAME is not set", async () => {
-    delete process.env["SLACK_TOKEN_SECRET_NAME"];
-
-    // 前のテストのキャッシュトークンをクリアするためモジュールをリセット
+  it("throws when userId is empty", async () => {
     const { getSlackToken, resetSlackTokenCache } = await import(
       "../ContextCollector.js"
     );
     resetSlackTokenCache();
 
-    await expect(getSlackToken()).rejects.toThrow("SLACK_TOKEN_SECRET_NAME");
+    await expect(getSlackToken("")).rejects.toThrow("userId is required");
   });
 
   it("throws when SecretString is empty", async () => {
@@ -76,10 +98,12 @@ describe("ContextCollector (getSlackToken)", () => {
     );
     resetSlackTokenCache();
 
-    await expect(getSlackToken()).rejects.toThrow("no SecretString");
+    await expect(getSlackToken("user-empty")).rejects.toThrow(
+      "no SecretString",
+    );
   });
 
-  it("ContextCollector class delegates to getSlackToken()", async () => {
+  it("ContextCollector class delegates to getSlackToken(userId)", async () => {
     mockSend.mockResolvedValueOnce({ SecretString: "xoxb-class-token" });
 
     const { ContextCollector, resetSlackTokenCache } = await import(
@@ -88,7 +112,7 @@ describe("ContextCollector (getSlackToken)", () => {
     resetSlackTokenCache();
 
     const collector = new ContextCollector();
-    const token = await collector.getSlackToken();
+    const token = await collector.getSlackToken("user-class");
 
     expect(token).toBe("xoxb-class-token");
   });

--- a/pkgs/agent/src/index.ts
+++ b/pkgs/agent/src/index.ts
@@ -32,7 +32,17 @@ export type {
 } from "./sabori-proposer/types.js";
 
 // コンテキストコレクター (共有)
-export { ContextCollector } from "./context-collector/ContextCollector.js";
+export {
+  ContextCollector,
+  getSlackToken,
+} from "./context-collector/ContextCollector.js";
+
+// Slack Web API クライアント
+export {
+  SlackApiError,
+  SlackClient,
+  type SlackHistoryMessage,
+} from "./slack-client/SlackClient.js";
 
 // ユーティリティ
 export type { SlackEventPayload, SlackMessage } from "./types/events.js";

--- a/pkgs/agent/src/sabori-proposer/SaboriProposerLambdaHandler.ts
+++ b/pkgs/agent/src/sabori-proposer/SaboriProposerLambdaHandler.ts
@@ -118,7 +118,7 @@ export const handler = async (event: unknown): Promise<LambdaResponse> => {
   let slackContext: SlackContext | undefined;
   if (payload.slackMessageRef) {
     try {
-      const token = await contextCollector.getSlackToken();
+      const token = await contextCollector.getSlackToken(payload.userId);
       // SlackContext 収集: 利用可能データから最小限のコンテキストを構築
       // 完全な Slack API 連携は U-04 で実装; ここでは基本コンテキストを構築
       slackContext = await collectMinimalSlackContext(

--- a/pkgs/agent/src/slack-client/SlackClient.ts
+++ b/pkgs/agent/src/slack-client/SlackClient.ts
@@ -1,0 +1,126 @@
+/**
+ * SlackClient — Slack Web API の薄いラッパー
+ *
+ * Bot Token (xoxb-) を受け取り、必要最小限の Slack API を呼び出す。
+ * - conversationsHistory: チャンネルの過去メッセージを取得（遡及タスク化）
+ * - postMessage: チャンネル/スレッドにメッセージを投稿（インタラクティブ返信）
+ *
+ * 設計:
+ * - fetch + AbortController で 5 秒タイムアウト（Lambda タイムアウトとの整合）
+ * - Slack API は HTTP 200 でも body の `ok:false` でエラーを返すため両方を検査
+ * - レート制限 (429) はそのままエラーとして伝播（呼び出し側で必要なら扱う）
+ */
+
+const SLACK_API_BASE = "https://slack.com/api";
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/** Slack のメッセージ要素（必要なフィールドのみ） */
+export interface SlackHistoryMessage {
+  type: string;
+  user?: string;
+  text?: string;
+  ts: string;
+  thread_ts?: string;
+  subtype?: string;
+  bot_id?: string;
+}
+
+export interface ConversationsHistoryParams {
+  channel: string;
+  /** Unix epoch（秒）。これより新しいメッセージのみ取得 */
+  oldest?: string;
+  /** 取得件数の上限（Slack 既定 100、最大 1000） */
+  limit?: number;
+}
+
+export interface PostMessageParams {
+  channel: string;
+  text: string;
+  /** スレッド返信にする場合は親メッセージの ts を指定 */
+  thread_ts?: string;
+}
+
+export class SlackApiError extends Error {
+  constructor(
+    public readonly slackError: string,
+    public readonly method: string,
+  ) {
+    super(`Slack API ${method} failed: ${slackError}`);
+    this.name = "SlackApiError";
+  }
+}
+
+export class SlackClient {
+  constructor(
+    private readonly botToken: string,
+    private readonly timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  ) {}
+
+  /**
+   * チャンネルの過去メッセージを取得する。
+   * 必要スコープ: channels:history / groups:history / im:history / mpim:history
+   */
+  async conversationsHistory(
+    params: ConversationsHistoryParams,
+  ): Promise<SlackHistoryMessage[]> {
+    const body = new URLSearchParams({
+      channel: params.channel,
+      ...(params.oldest ? { oldest: params.oldest } : {}),
+      limit: String(params.limit ?? 100),
+    });
+
+    const data = await this.call<{ messages?: SlackHistoryMessage[] }>(
+      "conversations.history",
+      body,
+    );
+    return data.messages ?? [];
+  }
+
+  /**
+   * チャンネル/スレッドにメッセージを投稿する。
+   * 必要スコープ: chat:write
+   */
+  async postMessage(params: PostMessageParams): Promise<{ ts: string }> {
+    const body = new URLSearchParams({
+      channel: params.channel,
+      text: params.text,
+      ...(params.thread_ts ? { thread_ts: params.thread_ts } : {}),
+    });
+
+    const data = await this.call<{ ts: string }>("chat.postMessage", body);
+    return { ts: data.ts };
+  }
+
+  /** Slack Web API を呼び出し、ok:false / タイムアウトをエラー化する */
+  private async call<T>(
+    method: string,
+    body: URLSearchParams,
+  ): Promise<T & { ok: boolean }> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch(`${SLACK_API_BASE}/${method}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.botToken}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new SlackApiError(`http_${res.status}`, method);
+      }
+
+      const data = (await res.json()) as T & { ok: boolean; error?: string };
+      if (!data.ok) {
+        throw new SlackApiError(data.error ?? "unknown_error", method);
+      }
+      return data;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/pkgs/agent/src/slack-client/__tests__/SlackClient.test.ts
+++ b/pkgs/agent/src/slack-client/__tests__/SlackClient.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SlackApiError, SlackClient } from "../SlackClient.js";
+
+/**
+ * SlackClient ユニットテスト
+ * fetch をモックして Slack Web API 呼び出しを検証する。
+ */
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function okResponse(payload: Record<string, unknown>) {
+  return {
+    ok: true, // HTTP ok
+    json: async () => ({ ok: true, ...payload }),
+  };
+}
+
+describe("SlackClient.conversationsHistory", () => {
+  it("returns messages on success", async () => {
+    mockFetch.mockResolvedValueOnce(
+      okResponse({
+        messages: [
+          { type: "message", user: "U1", text: "hello", ts: "1.1" },
+          { type: "message", user: "U2", text: "world", ts: "2.2" },
+        ],
+      }),
+    );
+
+    const client = new SlackClient("xoxb-test");
+    const msgs = await client.conversationsHistory({ channel: "C1" });
+
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].text).toBe("hello");
+    // 正しい API エンドポイント・認証ヘッダ
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://slack.com/api/conversations.history");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer xoxb-test",
+    );
+  });
+
+  it("passes oldest and limit params", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ messages: [] }));
+
+    const client = new SlackClient("xoxb-test");
+    await client.conversationsHistory({
+      channel: "C1",
+      oldest: "1700000000.000",
+      limit: 50,
+    });
+
+    const body = (mockFetch.mock.calls[0][1].body as string) ?? "";
+    expect(body).toContain("oldest=1700000000.000");
+    expect(body).toContain("limit=50");
+  });
+
+  it("returns empty array when messages is absent", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({}));
+
+    const client = new SlackClient("xoxb-test");
+    const msgs = await client.conversationsHistory({ channel: "C1" });
+    expect(msgs).toEqual([]);
+  });
+
+  it("throws SlackApiError on ok:false", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: false, error: "channel_not_found" }),
+    });
+
+    const client = new SlackClient("xoxb-test");
+    await expect(
+      client.conversationsHistory({ channel: "C-bad" }),
+    ).rejects.toThrow(SlackApiError);
+  });
+
+  it("throws SlackApiError on HTTP error status", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429 });
+
+    const client = new SlackClient("xoxb-test");
+    await expect(
+      client.conversationsHistory({ channel: "C1" }),
+    ).rejects.toThrow("http_429");
+  });
+
+  it("falls back to unknown_error when ok:false has no error field", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: false }), // error フィールドなし
+    });
+
+    const client = new SlackClient("xoxb-test");
+    await expect(
+      client.conversationsHistory({ channel: "C1" }),
+    ).rejects.toThrow("unknown_error");
+  });
+});
+
+describe("SlackClient.postMessage", () => {
+  it("posts a message and returns ts", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ ts: "9.9" }));
+
+    const client = new SlackClient("xoxb-test");
+    const result = await client.postMessage({ channel: "C1", text: "hi" });
+
+    expect(result.ts).toBe("9.9");
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://slack.com/api/chat.postMessage");
+  });
+
+  it("includes thread_ts for threaded replies", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ ts: "9.9" }));
+
+    const client = new SlackClient("xoxb-test");
+    await client.postMessage({
+      channel: "C1",
+      text: "reply",
+      thread_ts: "1.1",
+    });
+
+    const body = (mockFetch.mock.calls[0][1].body as string) ?? "";
+    expect(body).toContain("thread_ts=1.1");
+  });
+
+  it("throws SlackApiError on ok:false", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: false, error: "not_in_channel" }),
+    });
+
+    const client = new SlackClient("xoxb-test");
+    await expect(
+      client.postMessage({ channel: "C1", text: "x" }),
+    ).rejects.toThrow("not_in_channel");
+  });
+});
+
+describe("SlackClient timeout", () => {
+  it("aborts the request after the timeout", async () => {
+    // fetch が AbortSignal で reject される挙動を模擬
+    mockFetch.mockImplementationOnce((_url, init: { signal: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    });
+
+    const client = new SlackClient("xoxb-test", 10); // 10ms タイムアウト
+    await expect(
+      client.conversationsHistory({ channel: "C1" }),
+    ).rejects.toThrow();
+  });
+});

--- a/pkgs/agent/src/task-extractor/TaskExtractorLambdaHandler.ts
+++ b/pkgs/agent/src/task-extractor/TaskExtractorLambdaHandler.ts
@@ -2,6 +2,7 @@ import { BedrockClientAdapter } from "../bedrock/BedrockClientAdapter.js";
 import { DynamoSlackUserLookupRepository } from "../repositories/DynamoSlackUserLookupRepository.js";
 import { DynamoTaskCandidateRepository } from "../repositories/DynamoTaskCandidateRepository.js";
 import {
+  EventBridgeSlackBackfillSchema,
   EventBridgeSlackEventSchema,
   type SlackEventPayload,
 } from "../types/events.js";
@@ -9,18 +10,19 @@ import { logError, logInfo } from "../utils/logger.js";
 import { TaskExtractorAgent } from "./TaskExtractorAgent.js";
 
 /**
- * TaskExtractor の Lambda ハンドラー (U-03a)
+ * TaskExtractor の Lambda ハンドラー (U-03a / C 拡張)
  *
- * トリガー: EventBridge カスタムバス (saborou-event-bus-{env})
- *           SlackMessageRule 経由 (detail-type: "SlackMessage")
+ * 2 種類の EventBridge イベントを処理する:
+ * 1. SlackEvent (source: saborou.webhook) — Slack Webhook 由来。
+ *    teamId + Slack user から Cognito ユーザーを逆引きする。
+ * 2. SlackBackfill (source: saborou.backend) — 遡及取得 API 由来。
+ *    認証ユーザーの cognitoSub を直接持つため逆引き不要。
  *
  * CDK でのハンドラーパス: "task-extractor/TaskExtractorLambdaHandler.handler"
- * (tsup エントリー: "task-extractor/TaskExtractorLambdaHandler")
  *
  * NFR 設計:
  * - DP-03: エントリー時に EventBridge ペイロードの Zod バリデーション
  * - ValidationException はログ記録後に飲み込む (不正イベントは DLQ なし)
- *   理由: 不正イベントのリトライはリソースの無駄; DLQ は一時的な障害用。
  * - ランタイムエラー (Bedrock, DynamoDB) → 伝播 → Lambda リトライ → maxReceiveCount 後に DLQ
  */
 
@@ -31,19 +33,65 @@ const bedrockClient = new BedrockClientAdapter(
 const repository = new DynamoTaskCandidateRepository();
 const slackUserLookup = new DynamoSlackUserLookupRepository();
 
-export const handler = async (event: unknown): Promise<void> => {
-  // [1] EventBridge エンベロープを検証 (DP-03: 入力側)
-  const parsed = EventBridgeSlackEventSchema.safeParse(event);
-  if (!parsed.success) {
-    logError({
-      action: "invalid_input",
-      errors: parsed.error.issues,
+/** Bedrock でタスク抽出を実行し結果をログする共通処理 */
+async function runExtraction(payload: SlackEventPayload): Promise<void> {
+  const agent = new TaskExtractorAgent(bedrockClient, repository);
+  const result = await agent.extractTask(payload);
+  if (result.skipped) {
+    logInfo({ action: "skipped", sourceRef: payload.message.messageTs });
+  } else {
+    logInfo({
+      action: "completed",
+      candidateId: result.candidate.candidateId,
+      sourceRef: payload.message.messageTs,
     });
-    // スローせずに返す — 不正イベントは DLQ に送らない
+  }
+}
+
+export const handler = async (event: unknown): Promise<void> => {
+  // backfill (遡及取得 API 由来) を先に判定 — cognitoSub を直接持つ
+  const backfill = EventBridgeSlackBackfillSchema.safeParse(event);
+  if (backfill.success) {
+    await handleBackfill(backfill.data);
     return;
   }
 
-  const { detail } = parsed.data;
+  // Slack Webhook 由来イベント
+  const parsed = EventBridgeSlackEventSchema.safeParse(event);
+  if (!parsed.success) {
+    logError({ action: "invalid_input", errors: parsed.error.issues });
+    // スローせずに返す — 不正イベントは DLQ に送らない
+    return;
+  }
+  await handleSlackEvent(parsed.data);
+};
+
+/** SlackBackfill: cognitoSub を直接使う（逆引き不要） */
+async function handleBackfill(
+  data: import("../types/events.js").EventBridgeSlackBackfill,
+): Promise<void> {
+  const { userId, message } = data.detail;
+
+  const payload: SlackEventPayload = {
+    source: "slack",
+    userId,
+    message: {
+      text: message.text,
+      channelId: message.channel,
+      messageTs: message.ts,
+      teamId: message.team,
+      userId: message.user,
+      ...(message.thread_ts ? { threadTs: message.thread_ts } : {}),
+    },
+  };
+  await runExtraction(payload);
+}
+
+/** SlackEvent: teamId + Slack user から Cognito ユーザーを逆引きする */
+async function handleSlackEvent(
+  data: import("../types/events.js").EventBridgeSlackEvent,
+): Promise<void> {
+  const { detail } = data;
   const rawEvent = detail.event;
 
   // ボットメッセージ・サブタイプ付きメッセージはスキップ (無限ループ防止)
@@ -65,16 +113,10 @@ export const handler = async (event: unknown): Promise<void> => {
     rawEvent.user,
   );
   if (!cognitoSub) {
-    logInfo({
-      action: "skipped_unlinked_slack_user",
-      teamId: detail.teamId,
-    });
+    logInfo({ action: "skipped_unlinked_slack_user", teamId: detail.teamId });
     return;
   }
 
-  // EventBridge エンベロープ → ドメイン型に変換
-  // userId は Cognito sub（逆引き結果）。message.userId は Slack user ID
-  // （TaskExtractorAgent が依頼者の仮名化に使用）。
   const payload: SlackEventPayload = {
     source: "slack",
     userId: cognitoSub,
@@ -87,22 +129,5 @@ export const handler = async (event: unknown): Promise<void> => {
       ...(rawEvent.thread_ts ? { threadTs: rawEvent.thread_ts } : {}),
     },
   };
-
-  // [2] タスクを抽出
-  const agent = new TaskExtractorAgent(bedrockClient, repository);
-  const result = await agent.extractTask(payload);
-
-  // [3] 結果をログ
-  if (result.skipped) {
-    logInfo({
-      action: "skipped",
-      sourceRef: payload.message.messageTs,
-    });
-  } else {
-    logInfo({
-      action: "completed",
-      candidateId: result.candidate.candidateId,
-      sourceRef: payload.message.messageTs,
-    });
-  }
-};
+  await runExtraction(payload);
+}

--- a/pkgs/agent/src/task-extractor/__tests__/TaskExtractorLambdaHandler.test.ts
+++ b/pkgs/agent/src/task-extractor/__tests__/TaskExtractorLambdaHandler.test.ts
@@ -274,4 +274,51 @@ describe("TaskExtractorLambdaHandler", () => {
     expect(mockFindCognitoSub).not.toHaveBeenCalled();
     expect(mockConverse).not.toHaveBeenCalled();
   });
+
+  // ── SlackBackfill 経路（遡及取得 API 由来・cognitoSub 直接） ──
+
+  const validBackfillEvent = {
+    source: "saborou.backend",
+    "detail-type": "SlackBackfill",
+    detail: {
+      userId: "cognito-user-abc",
+      message: {
+        text: "遡及取得した依頼です。",
+        channel: "C12345",
+        ts: "1234567890.123456",
+        user: "U99999",
+        team: "T12345",
+      },
+      receivedAt: "2026-05-23T00:00:00.000Z",
+    },
+  };
+
+  it("processes a backfill event without reverse lookup", async () => {
+    mockConverse.mockResolvedValueOnce(makeToolUseResponse());
+
+    const { handler } = await import("../TaskExtractorLambdaHandler.js");
+    await expect(handler(validBackfillEvent)).resolves.toBeUndefined();
+    // backfill は cognitoSub を直接持つので逆引きは呼ばれない
+    expect(mockFindCognitoSub).not.toHaveBeenCalled();
+    expect(mockConverse).toHaveBeenCalledOnce();
+  });
+
+  it("includes threadTs for backfill events with thread_ts", async () => {
+    mockConverse.mockResolvedValueOnce(makeToolUseResponse());
+
+    const threadedBackfill = {
+      ...validBackfillEvent,
+      detail: {
+        ...validBackfillEvent.detail,
+        message: {
+          ...validBackfillEvent.detail.message,
+          thread_ts: "1234567880.000000",
+        },
+      },
+    };
+
+    const { handler } = await import("../TaskExtractorLambdaHandler.js");
+    await expect(handler(threadedBackfill)).resolves.toBeUndefined();
+    expect(mockConverse).toHaveBeenCalledOnce();
+  });
 });

--- a/pkgs/agent/src/types/events.ts
+++ b/pkgs/agent/src/types/events.ts
@@ -50,3 +50,32 @@ export const EventBridgeSlackEventSchema = z.object({
 });
 
 export type EventBridgeSlackEvent = z.infer<typeof EventBridgeSlackEventSchema>;
+
+// ---- 遡及取得 (backfill) エンベロープ ----
+// 認証済みユーザーが自分のチャンネル履歴を同期する際に backend が publish する。
+// Webhook 経路と違い cognitoSub を直接持つため逆引きは不要。
+
+export const SlackBackfillDetailSchema = z.object({
+  // 同期を要求した Cognito ユーザー (cognitoSub)
+  userId: z.string().min(1),
+  // 取り込む 1 件の Slack メッセージ
+  message: z.object({
+    text: z.string().min(1),
+    channel: z.string().min(1),
+    ts: z.string().min(1),
+    thread_ts: z.string().optional(),
+    user: z.string().optional().default(""),
+    team: z.string().optional().default(""),
+  }),
+  receivedAt: z.string(),
+});
+
+export const EventBridgeSlackBackfillSchema = z.object({
+  source: z.literal("saborou.backend"),
+  "detail-type": z.literal("SlackBackfill"),
+  detail: SlackBackfillDetailSchema,
+});
+
+export type EventBridgeSlackBackfill = z.infer<
+  typeof EventBridgeSlackBackfillSchema
+>;

--- a/pkgs/backend/src/__tests__/routes/slack.test.ts
+++ b/pkgs/backend/src/__tests__/routes/slack.test.ts
@@ -1,0 +1,283 @@
+/**
+ * POST /api/slack/sync-messages のテスト
+ *
+ * モック対象:
+ * - @saboru/agent の getSlackToken / SlackClient
+ * - EventBridgeClient.send（DI で注入）
+ */
+
+import type { EventBridgeClient } from "@aws-sdk/client-eventbridge";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../../middleware/error-handler.js";
+import type { DynamoProposalRepository } from "../../repositories/DynamoProposalRepository.js";
+import type { DynamoTaskRepository } from "../../repositories/DynamoTaskRepository.js";
+import type { AppEnv } from "../../types.js";
+
+const { mockGetSlackToken, mockConversationsHistory, mockPostMessage } =
+  vi.hoisted(() => ({
+    mockGetSlackToken: vi.fn(),
+    mockConversationsHistory: vi.fn(),
+    mockPostMessage: vi.fn(),
+  }));
+
+vi.mock("@saboru/agent", () => ({
+  getSlackToken: mockGetSlackToken,
+  SlackClient: class {
+    conversationsHistory = mockConversationsHistory;
+    postMessage = mockPostMessage;
+  },
+}));
+
+vi.mock("../../config/env.js", () => ({
+  env: {
+    EVENT_BUS_NAME: "test-bus",
+  },
+}));
+
+const MOCK_USER_ID = "cognito-slack-test";
+
+interface RepoOverrides {
+  taskFindById?: ReturnType<typeof vi.fn>;
+  proposalFindLatest?: ReturnType<typeof vi.fn>;
+}
+
+function buildApp(ebSend: ReturnType<typeof vi.fn>, repos: RepoOverrides = {}) {
+  const ebClient = { send: ebSend } as unknown as EventBridgeClient;
+  const taskRepo = {
+    findById: repos.taskFindById ?? vi.fn(),
+  } as unknown as DynamoTaskRepository;
+  const proposalRepo = {
+    findLatestByTaskId: repos.proposalFindLatest ?? vi.fn(),
+  } as unknown as DynamoProposalRepository;
+
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    (c as unknown as { env: unknown }).env = {
+      requestContext: {
+        authorizer: { jwt: { claims: { sub: MOCK_USER_ID } } },
+      },
+    };
+    await next();
+  });
+  // 動的 import で vi.mock 適用後にルートを読み込む
+  return import("../../routes/slack.js").then(({ createSlackRoute }) => {
+    app.route("/api/slack", createSlackRoute(taskRepo, proposalRepo, ebClient));
+    app.onError(errorHandler);
+    return app;
+  });
+}
+
+describe("POST /api/slack/sync-messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSlackToken.mockResolvedValue("xoxb-test");
+  });
+
+  it("queues taskable messages to EventBridge and returns counts", async () => {
+    mockConversationsHistory.mockResolvedValueOnce([
+      { type: "message", user: "U1", text: "資料作って", ts: "1.1" },
+      { type: "message", user: "U2", text: "確認お願いします", ts: "2.2" },
+      // 除外対象
+      { type: "message", bot_id: "B1", text: "bot post", ts: "3.3" },
+      { type: "message", subtype: "channel_join", text: "joined", ts: "4.4" },
+      { type: "message", user: "U3", text: "   ", ts: "5.5" },
+    ]);
+    const ebSend = vi.fn().mockResolvedValue({ FailedEntryCount: 0 });
+
+    const app = await buildApp(ebSend);
+    const res = await app.request("/api/slack/sync-messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channelId: "C1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scanned).toBe(5);
+    expect(body.queued).toBe(2); // taskable は2件のみ
+    expect(ebSend).toHaveBeenCalledOnce();
+    expect(mockGetSlackToken).toHaveBeenCalledWith(MOCK_USER_ID);
+  });
+
+  it("returns queued=0 when no taskable messages", async () => {
+    mockConversationsHistory.mockResolvedValueOnce([
+      { type: "message", bot_id: "B1", text: "bot", ts: "1.1" },
+    ]);
+    const ebSend = vi.fn();
+
+    const app = await buildApp(ebSend);
+    const res = await app.request("/api/slack/sync-messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channelId: "C1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.queued).toBe(0);
+    // publish 対象がないので EventBridge は呼ばれない
+    expect(ebSend).not.toHaveBeenCalled();
+  });
+
+  it("passes oldest and limit to conversationsHistory", async () => {
+    mockConversationsHistory.mockResolvedValueOnce([]);
+    const ebSend = vi.fn();
+
+    const app = await buildApp(ebSend);
+    await app.request("/api/slack/sync-messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        channelId: "C9",
+        oldest: "1700000000.0",
+        limit: 20,
+      }),
+    });
+
+    expect(mockConversationsHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C9",
+        oldest: "1700000000.0",
+        limit: 20,
+      }),
+    );
+  });
+
+  it("returns 400 for invalid body (missing channelId)", async () => {
+    const ebSend = vi.fn();
+    const app = await buildApp(ebSend);
+    const res = await app.request("/api/slack/sync-messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("batches EventBridge entries in groups of 10", async () => {
+    // 12件の taskable → 2バッチ（10 + 2）
+    const messages = Array.from({ length: 12 }, (_, i) => ({
+      type: "message",
+      user: `U${i}`,
+      text: `task ${i}`,
+      ts: `${i}.0`,
+    }));
+    mockConversationsHistory.mockResolvedValueOnce(messages);
+    const ebSend = vi.fn().mockResolvedValue({ FailedEntryCount: 0 });
+
+    const app = await buildApp(ebSend);
+    const res = await app.request("/api/slack/sync-messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channelId: "C1" }),
+    });
+
+    const body = await res.json();
+    expect(body.queued).toBe(12);
+    expect(ebSend).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("POST /api/slack/notify-task", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSlackToken.mockResolvedValue("xoxb-test");
+    mockPostMessage.mockResolvedValue({ ts: "9.9" });
+  });
+
+  const task = {
+    PK: `USER#${MOCK_USER_ID}`,
+    SK: "TASK#t1",
+    taskId: "t1",
+    userId: MOCK_USER_ID,
+    status: "approved",
+    title: "資料作成",
+    deadline: null,
+    requester: "",
+    description: "",
+    sourceType: "slack",
+    approvedAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z",
+  };
+
+  it("posts the latest verdict to Slack and returns ts", async () => {
+    const taskFindById = vi.fn().mockResolvedValue(task);
+    const proposalFindLatest = vi
+      .fn()
+      .mockResolvedValue({ verdict: "can_saboru" });
+
+    const app = await buildApp(vi.fn(), {
+      taskFindById,
+      proposalFindLatest,
+    });
+    const res = await app.request("/api/slack/notify-task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ taskId: "t1", channelId: "C1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.posted).toBe(true);
+    expect(body.verdict).toBe("can_saboru");
+    // postMessage に verdict 由来のメッセージが渡る
+    const arg = mockPostMessage.mock.calls[0][0];
+    expect(arg.channel).toBe("C1");
+    expect(arg.text).toContain("資料作成");
+  });
+
+  it("falls back to borderline when no proposal exists", async () => {
+    const taskFindById = vi.fn().mockResolvedValue(task);
+    const proposalFindLatest = vi.fn().mockResolvedValue(null);
+
+    const app = await buildApp(vi.fn(), { taskFindById, proposalFindLatest });
+    const res = await app.request("/api/slack/notify-task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ taskId: "t1", channelId: "C1" }),
+    });
+
+    const body = await res.json();
+    expect(body.verdict).toBe("borderline");
+  });
+
+  it("passes threadTs for threaded replies", async () => {
+    const taskFindById = vi.fn().mockResolvedValue(task);
+    const proposalFindLatest = vi
+      .fn()
+      .mockResolvedValue({ verdict: "must_do" });
+
+    const app = await buildApp(vi.fn(), { taskFindById, proposalFindLatest });
+    await app.request("/api/slack/notify-task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ taskId: "t1", channelId: "C1", threadTs: "1.1" }),
+    });
+
+    expect(mockPostMessage.mock.calls[0][0].thread_ts).toBe("1.1");
+  });
+
+  it("returns 404 when the task is not found / not owned", async () => {
+    const taskFindById = vi.fn().mockResolvedValue(null);
+    const app = await buildApp(vi.fn(), { taskFindById });
+    const res = await app.request("/api/slack/notify-task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ taskId: "missing", channelId: "C1" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid body (missing taskId)", async () => {
+    const app = await buildApp(vi.fn());
+    const res = await app.request("/api/slack/notify-task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channelId: "C1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/pkgs/backend/src/index.ts
+++ b/pkgs/backend/src/index.ts
@@ -48,6 +48,7 @@ import { createConnectionsRoute } from "./routes/connections.js";
 import { healthRoute } from "./routes/health.js";
 import { createHonneRoute } from "./routes/honne.js";
 import { createProposalsRoute } from "./routes/proposals.js";
+import { createSlackRoute } from "./routes/slack.js";
 import { createTasksRoute } from "./routes/tasks.js";
 import { createUsersRoute } from "./routes/users.js";
 
@@ -126,6 +127,10 @@ export function createApp() {
     createHonneRoute(taskRepository, honneRepository, proposalRepository),
   );
   app.route("/api/connections", createConnectionsRoute(connectionRepository));
+  app.route(
+    "/api/slack",
+    createSlackRoute(taskRepository, proposalRepository),
+  );
 
   // OpenAPI / Swagger UI
   app.get("/doc", (c) => c.json(openApiDoc));

--- a/pkgs/backend/src/routes/auth.ts
+++ b/pkgs/backend/src/routes/auth.ts
@@ -35,6 +35,8 @@ const SLACK_OAUTH_SCOPES = [
   "im:history",
   "mpim:history",
   "users:read",
+  // chat:write: サボり提案を Slack スレッドに返信する（インタラクティブ化）
+  "chat:write",
 ].join(",");
 
 const SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize";

--- a/pkgs/backend/src/routes/slack.ts
+++ b/pkgs/backend/src/routes/slack.ts
@@ -1,0 +1,183 @@
+/**
+ * Slack 連携ルート（Bot Token を能動的に使う操作）
+ *
+ * POST /api/slack/sync-messages — 認証ユーザーの Slack チャンネル履歴を遡及取得し、
+ *   各メッセージを EventBridge (SlackBackfill) に publish して TaskExtractor で
+ *   タスク候補化する。「Slack からタスク一覧を取得する」ユーザー要望に対応。
+ *
+ * POST /api/slack/notify-task — タスクのサボり判定を Slack チャンネル/スレッドに
+ *   投稿する（chat.postMessage）。「Bot Token でインタラクティブなやり取り」に対応。
+ *
+ * 設計:
+ * - 認証ユーザー（cognitoSub）の per-user Bot Token を Secrets Manager から取得
+ * - conversations.history を呼び、ボット/サブタイプ/空メッセージを除外
+ * - 各メッセージを SlackBackfill イベントとして publish（userId を直接保持＝逆引き不要）
+ */
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { zValidator } from "@hono/zod-validator";
+import { SlackClient, getSlackToken } from "@saboru/agent";
+import { Hono } from "hono";
+import { z } from "zod";
+import { env } from "../config/env.js";
+import { NotFoundError } from "../errors.js";
+import { authMiddleware } from "../middleware/auth.js";
+import type { DynamoProposalRepository } from "../repositories/DynamoProposalRepository.js";
+import type { DynamoTaskRepository } from "../repositories/DynamoTaskRepository.js";
+import type { AppEnv } from "../types.js";
+
+const SyncMessagesSchema = z.object({
+  channelId: z.string().min(1),
+  /** Unix epoch（秒）。これより新しいメッセージのみ取り込む */
+  oldest: z.string().optional(),
+  /** 取り込む最大件数（1〜200） */
+  limit: z.number().int().min(1).max(200).optional(),
+});
+
+const NotifyTaskSchema = z.object({
+  taskId: z.string().min(1),
+  channelId: z.string().min(1),
+  /** スレッド返信にする場合の親メッセージ ts */
+  threadTs: z.string().optional(),
+});
+
+/** verdict をサボロー口調の一言メッセージにする */
+function verdictToMessage(verdict: string, title: string): string {
+  switch (verdict) {
+    case "can_saboru":
+      return `😴「${title}」は今サボってもよさそうだよ〜`;
+    case "borderline":
+      return `🤔「${title}」は微妙なライン。様子見かな`;
+    case "must_do":
+      return `⚡「${title}」はそろそろやった方がいいかも！`;
+    default:
+      return `「${title}」の判定が出たよ`;
+  }
+}
+
+export function createSlackRoute(
+  taskRepository: DynamoTaskRepository,
+  proposalRepository: DynamoProposalRepository,
+  ebClient: EventBridgeClient = new EventBridgeClient({
+    region: process.env.AWS_REGION ?? "ap-northeast-1",
+  }),
+): Hono<AppEnv> {
+  const slack = new Hono<AppEnv>();
+  slack.use("*", authMiddleware);
+
+  /** POST /api/slack/sync-messages — Slack 履歴を遡及取得してタスク化キューへ投入 */
+  slack.post(
+    "/sync-messages",
+    zValidator("json", SyncMessagesSchema, (result, c) => {
+      if (!result.success) {
+        return c.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "Invalid request body",
+              details: result.error.flatten(),
+            },
+          },
+          400,
+        );
+      }
+    }),
+    async (c) => {
+      const userId = c.get("userId");
+      const { channelId, oldest, limit } = c.req.valid("json");
+
+      // per-user Bot Token を取得（未連携なら Secrets Manager が失敗 → 500）
+      const botToken = await getSlackToken(userId);
+      const client = new SlackClient(botToken);
+
+      const messages = await client.conversationsHistory({
+        channel: channelId,
+        ...(oldest ? { oldest } : {}),
+        ...(limit ? { limit } : {}),
+      });
+
+      // ボット・サブタイプ・空テキストを除外
+      const taskable = messages.filter(
+        (m) => !m.bot_id && !m.subtype && m.text && m.text.trim().length > 0,
+      );
+
+      // 各メッセージを SlackBackfill イベントとして publish
+      const entries = taskable.map((m) => ({
+        Source: "saborou.backend",
+        DetailType: "SlackBackfill",
+        Detail: JSON.stringify({
+          userId,
+          message: {
+            text: m.text,
+            channel: channelId,
+            ts: m.ts,
+            ...(m.thread_ts ? { thread_ts: m.thread_ts } : {}),
+            user: m.user ?? "",
+          },
+          receivedAt: new Date().toISOString(),
+        }),
+        EventBusName: env.EVENT_BUS_NAME,
+      }));
+
+      let queued = 0;
+      if (entries.length > 0) {
+        // EventBridge PutEvents は1リクエスト最大10件
+        for (let i = 0; i < entries.length; i += 10) {
+          const batch = entries.slice(i, i + 10);
+          const result = await ebClient.send(
+            new PutEventsCommand({ Entries: batch }),
+          );
+          queued += batch.length - (result.FailedEntryCount ?? 0);
+        }
+      }
+
+      return c.json({ scanned: messages.length, queued });
+    },
+  );
+
+  /** POST /api/slack/notify-task — タスクのサボり判定を Slack に投稿（chat.postMessage） */
+  slack.post(
+    "/notify-task",
+    zValidator("json", NotifyTaskSchema, (result, c) => {
+      if (!result.success) {
+        return c.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "Invalid request body",
+              details: result.error.flatten(),
+            },
+          },
+          400,
+        );
+      }
+    }),
+    async (c) => {
+      const userId = c.get("userId");
+      const { taskId, channelId, threadTs } = c.req.valid("json");
+
+      // タスクの所有者確認（他人のタスクは投稿させない）
+      const task = await taskRepository.findById(userId, taskId);
+      if (!task) throw new NotFoundError(`Task ${taskId} not found`);
+
+      // 最新のサボり判定を取得
+      const proposal = await proposalRepository.findLatestByTaskId(taskId);
+      const verdict = proposal?.verdict ?? "borderline";
+
+      const botToken = await getSlackToken(userId);
+      const client = new SlackClient(botToken);
+      const result = await client.postMessage({
+        channel: channelId,
+        text: verdictToMessage(verdict, task.title),
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      });
+
+      return c.json({ posted: true, ts: result.ts, verdict });
+    },
+  );
+
+  return slack;
+}

--- a/pkgs/cdk/lib/stacks/agent-stack.ts
+++ b/pkgs/cdk/lib/stacks/agent-stack.ts
@@ -102,10 +102,20 @@ export class SaborouAgentStack extends cdk.Stack {
         // Slack identity → Cognito user 逆引き用（GSI-SlackLookup を引く）
         DYNAMODB_TABLE_CONNECTIONS: props.data.tables.connections.tableName,
         BEDROCK_REGION: "ap-northeast-1",
-        SLACK_TOKEN_SECRET_NAME:
-          props.data.secrets.slackClientSecret.secretName,
+        // per-user の Slack Bot Token シークレット名プレフィックス。
+        // ContextCollector が `${prefix}${cognitoSub}` で個別トークンを取得する。
+        SLACK_BOT_TOKEN_SECRET_PREFIX: `saborou/slack-bot-token/`,
         PSEUDONYMIZE_SALT: pseudonymizeSalt,
       },
+    });
+
+    // --- per-user Slack Bot Token への読み取り権限（OAuth で saborou/slack-bot-token/<sub> に保存される） ---
+    const slackBotTokenReadPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["secretsmanager:GetSecretValue"],
+      resources: [
+        `arn:aws:secretsmanager:${this.region}:${this.account}:secret:saborou/slack-bot-token/*`,
+      ],
     });
 
     // --- AWS Marketplace 権限 (Bedrock モデルアクセス確認に必要) ---
@@ -121,11 +131,11 @@ export class SaborouAgentStack extends cdk.Stack {
 
     taskExtractorFn.addToRolePolicy(bedrockPolicy);
     taskExtractorFn.addToRolePolicy(marketplacePolicy);
+    taskExtractorFn.addToRolePolicy(slackBotTokenReadPolicy);
     props.data.tables.taskCandidates.grantReadWriteData(taskExtractorFn);
     props.data.tables.tasks.grantReadData(taskExtractorFn);
     // Slack identity → Cognito user 逆引き（GSI-SlackLookup を含む読み取り）
     props.data.tables.connections.grantReadData(taskExtractorFn);
-    props.data.secrets.slackClientSecret.grantRead(taskExtractorFn);
 
     // --- SaboriProposer DLQ ---
     const saboriProposerDlq = new sqs.Queue(this, "SaboriProposerDlq", {
@@ -162,9 +172,8 @@ export class SaborouAgentStack extends cdk.Stack {
         DYNAMODB_TABLE_PROPOSALS: props.data.tables.proposals.tableName,
         DYNAMODB_TABLE_TASKS: props.data.tables.tasks.tableName,
         BEDROCK_REGION: "ap-northeast-1",
-        // U-03b: ARN ではなく secretName を使用 — ContextCollector が SLACK_TOKEN_SECRET_NAME を参照するため
-        SLACK_TOKEN_SECRET_NAME:
-          props.data.secrets.slackClientSecret.secretName,
+        // per-user の Slack Bot Token シークレット名プレフィックス（ContextCollector が参照）
+        SLACK_BOT_TOKEN_SECRET_PREFIX: `saborou/slack-bot-token/`,
         // DYNAMODB_TABLE_PERSONAS: 削除 (MVP スコープ — U-03b では未使用)
         PSEUDONYMIZE_SALT: pseudonymizeSalt,
       },
@@ -172,10 +181,12 @@ export class SaborouAgentStack extends cdk.Stack {
 
     saboriProposerFn.addToRolePolicy(bedrockPolicy);
     saboriProposerFn.addToRolePolicy(marketplacePolicy);
+    saboriProposerFn.addToRolePolicy(slackBotTokenReadPolicy);
     props.data.tables.proposals.grantReadWriteData(saboriProposerFn);
     props.data.tables.tasks.grantReadData(saboriProposerFn);
     // personas テーブルの権限付与を削除 (MVP スコープ)
-    props.data.secrets.slackClientSecret.grantRead(saboriProposerFn);
+    // Slack Bot Token は per-user シークレットのため slackBotTokenReadPolicy で付与済み
+    // （旧: slackClientSecret.grantRead は OAuth Client Secret 用で Bot Token とは無関係だったため削除）
 
     // --- CfnOutputs ---
     new cdk.CfnOutput(this, "TaskExtractorFnArn", {

--- a/pkgs/cdk/lib/stacks/api-stack.ts
+++ b/pkgs/cdk/lib/stacks/api-stack.ts
@@ -68,8 +68,15 @@ export class SaborouApiStack extends cdk.Stack {
           this,
           "/saborou/oauth/state-secret",
         ),
-        // 注: EVENT_BUS_NAME は API Lambda では不要 (webhook Lambda のみが使用)
-        // Bedrock: SaboriProposerAgent が API Lambda 内で直接 Bedrock を呼び出すため us-east-1 を指定
+        // Slack 遡及取得 API (POST /api/slack/sync-messages) が EventBridge へ
+        // SlackBackfill イベントを publish するため必要。
+        // WebhookStack → ApiStack の依存方向のため循環回避で固定名を使う
+        // （WebhookStack の eventBusName と一致させること）。
+        EVENT_BUS_NAME: `saborou-event-bus-${environment}`,
+        // per-user の Slack Bot Token シークレット名プレフィックス
+        // （遡及取得 API が認証ユーザーの Bot Token を取得するため）
+        SLACK_BOT_TOKEN_SECRET_PREFIX: `saborou/slack-bot-token/`,
+        // Bedrock: SaboriProposerAgent が API Lambda 内で直接 Bedrock を呼び出す
         BEDROCK_REGION: "ap-northeast-1",
       },
     });
@@ -116,6 +123,28 @@ export class SaborouApiStack extends cdk.Stack {
 
     // --- Secrets Manager 権限付与 (追加: U-04 Slack OAuth) ---
     props.data.secrets.slackClientSecret.grantRead(honoFn);
+
+    // --- per-user Slack Bot Token 読み取り権限（遡及取得 API が使用） ---
+    honoFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["secretsmanager:GetSecretValue"],
+        resources: [
+          `arn:aws:secretsmanager:${this.region}:${this.account}:secret:saborou/slack-bot-token/*`,
+        ],
+      }),
+    );
+
+    // --- EventBridge PutEvents 権限（遡及取得 API が SlackBackfill を publish） ---
+    honoFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["events:PutEvents"],
+        resources: [
+          `arn:aws:events:${this.region}:${this.account}:event-bus/saborou-event-bus-${environment}`,
+        ],
+      }),
+    );
 
     // --- JWT オーソライザー ---
     const authorizer = new apigatewayv2Authorizers.HttpJwtAuthorizer(


### PR DESCRIPTION
## 概要

ユーザー要望の3点を実装します。機能改修バックログの **タスクC**（A→B→**C**→D→E→F→G）です。タスクB（slackUserId 紐付け・逆引き基盤）の上に構築しています。

1. **Bot Token化手順が抜けている** → 不整合修正＋手順整備
2. **Bot Token でインタラクティブなやり取り** → サボり判定の Slack 返信
3. **Slackからタスク一覧取得** → Slack 履歴の遡及タスク化

## 🔧 最重要：Bot Token 取得の不整合を修正

調査で重大なバグを発見しました。

- Bot Token は OAuth で **per-user**（`saborou/slack-bot-token/{userId}`）に保存される
- しかし `ContextCollector` は env `SLACK_TOKEN_SECRET_NAME` を読み、CDK はそこに **OAuth用 Client Secret**（`slackClientSecret`）を渡していた
- → ContextCollector は Bot Token ではなく Client Secret を取得し、per-user トークンに**到達できなかった**

これを **per-user Bot Token 取得**（`getSlackToken(userId)` / `SLACK_BOT_TOKEN_SECRET_PREFIX`）に修正しました。

## 変更内容

| レイヤ | 変更 |
|---|---|
| **agent** | `SlackClient`（conversations.history / chat.postMessage、5秒タイムアウト、`ok:false` エラー化）を新規。`ContextCollector` を per-user Bot Token 取得に修正（userId 別キャッシュ）。`TaskExtractorLambdaHandler` を `SlackEvent`(逆引き)/`SlackBackfill`(userId直接) の両対応に分岐。`events.ts` に backfill スキーマ追加 |
| **backend** | `POST /api/slack/sync-messages`（Slack履歴→EventBridge backfill publish）と `POST /api/slack/notify-task`（判定をSlack投稿）を新規。OAuth スコープに `chat:write` 追加 |
| **cdk** | agent/api Lambda に per-user Bot Token（`saborou/slack-bot-token/*`）の `GetSecretValue` 権限・`SLACK_BOT_TOKEN_SECRET_PREFIX` env を付与。api に `EVENT_BUS_NAME`（固定名で循環依存回避）・`events:PutEvents` を追加。誤った `SLACK_TOKEN_SECRET_NAME=clientSecret` を廃止 |
| **docs** | `slack-app-setup.md` に Bot Token化手順（`chat:write`・per-user保存の仕組み・再認可注意）を追記。`slack-api-integration.md` を新規作成 |

## データフロー

**遡及取得**: `POST /sync-messages` → Bot Token取得 → `conversations.history` → bot/subtype/空を除外 → EventBridge `SlackBackfill`(userId直接) → TaskExtractor（逆引き不要）→ タスク候補化

**返信**: `POST /notify-task` → 所有者確認 → 最新Proposalのverdict取得 → `chat.postMessage` でサボロー口調投稿

## テスト・品質

- ✅ shared **103** / backend **212** / agent **169** 全テストパス（SlackClient・slackルート・backfill経路など新規多数）
- ✅ agent カバレッジ **100% 維持**
- ✅ 型チェック（shared/backend/agent/cdk）通過 / ✅ `cdk synth`（Agent/Api）成功
- Biome エラー総数：変更前 168 → 変更後 165（悪化なし）

## 動作確認

- ローカル：全パッケージのテスト・型チェック・CDK synth で確認
- ⚠️ 実 Slack API 呼び出し（履歴取得・投稿）と実 OAuth（`chat:write` 再認可）は**実 AWS + 実 Slack アプリでの検証が必要**。本PRでタスクB（Slack紐付け）と合わせて E2E 確認できる土台が揃いました。

## レビュー観点
- Bot Token 不整合の修正方針（per-user 取得）が妥当か
- `EVENT_BUS_NAME` を固定名にした循環依存回避（WebhookStack→ApiStack のため）
- per-user シークレットのワイルドカード IAM 権限（`saborou/slack-bot-token/*`）のスコープ