### PR TITLE
fix(bedrock): 口調変換モデルを Haiku 3.5 → Haiku 4.5 に変更

### DIFF
--- a/pkgs/agent/src/sabori-proposer/PersonaRenderer.ts
+++ b/pkgs/agent/src/sabori-proposer/PersonaRenderer.ts
@@ -16,14 +16,15 @@ import type { RenderInput, RenderOutput } from "./types.js";
  * Claude Haiku (短文変換にコスト最適化) を使用して、中立的な LLM の
  * rawChatMessage をサボロー口調に変換する。
  *
- * モデル: anthropic.claude-haiku-3-5-20241022-v1:0
+ * モデル: jp.anthropic.claude-haiku-4-5-20251001-v1:0（JP クロスリージョン推論プロファイル）
+ *   ※ Haiku 3.5 は ap-northeast-1 に存在しないため Haiku 4.5 を使用
  * maxTokens: 256 (口調変換は出力が短い)
- * temperature: 0.3 (自然に聞こえる口調のためわずかな創造性)
+ * temperature: ペルソナごとに切替 (自然に聞こえる口調のためわずかな創造性)
  *
  * フォールバック: Haiku 呼び出し失敗時は rawChatMessage をそのまま使用 (NFR: グレースフルデグレード)
  */
 
-const HAIKU_MODEL_ID = "anthropic.claude-3-5-haiku-20241022-v1:0";
+const HAIKU_MODEL_ID = "jp.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 export class PersonaRenderer {
   constructor(private readonly bedrock: IBedrockClient) {}

--- a/pkgs/cdk/lib/stacks/agent-stack.ts
+++ b/pkgs/cdk/lib/stacks/agent-stack.ts
@@ -61,6 +61,11 @@ export class SaborouAgentStack extends cdk.Stack {
         "arn:aws:bedrock:ap-northeast-3::foundation-model/anthropic.claude-sonnet-4-6",
         "arn:aws:bedrock:ap-southeast-1::foundation-model/anthropic.claude-sonnet-4-6",
         "arn:aws:bedrock:ap-southeast-2::foundation-model/anthropic.claude-sonnet-4-6",
+        // Claude Haiku 4.5 (PersonaRenderer 口調変換): JP Geo 推論プロファイル
+        // ※ Haiku 3.5 は ap-northeast-1 に存在しないため 4.5 を使用
+        `arn:aws:bedrock:ap-northeast-1:${this.account}:inference-profile/jp.anthropic.claude-haiku-4-5-20251001-v1:0`,
+        "arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+        "arn:aws:bedrock:ap-northeast-3::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
       ],
     });
 

--- a/pkgs/cdk/lib/stacks/api-stack.ts
+++ b/pkgs/cdk/lib/stacks/api-stack.ts
@@ -91,9 +91,11 @@ export class SaborouApiStack extends cdk.Stack {
           `arn:aws:bedrock:ap-northeast-1:${this.account}:inference-profile/jp.anthropic.claude-sonnet-4-6`,
           `arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-sonnet-4-6`,
           `arn:aws:bedrock:ap-northeast-3::foundation-model/anthropic.claude-sonnet-4-6`,
-          // Claude Haiku 3.5 (PersonaRenderer): inference-profile ARN にはアカウント ID が必要
-          `arn:aws:bedrock:ap-northeast-1:${this.account}:inference-profile/ap.anthropic.claude-3-5-haiku-20241022-v1:0`,
-          `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0`,
+          // Claude Haiku 4.5 (PersonaRenderer): JP Geo クロスリージョン推論プロファイル
+          // ※ Haiku 3.5 は ap-northeast-1 に存在しないため 4.5 を使用
+          `arn:aws:bedrock:ap-northeast-1:${this.account}:inference-profile/jp.anthropic.claude-haiku-4-5-20251001-v1:0`,
+          `arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0`,
+          `arn:aws:bedrock:ap-northeast-3::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0`,
         ],
       }),
     );


### PR DESCRIPTION
## 概要

実AWSデプロイ前の調査で、口調変換（PersonaRenderer）が使う **Haiku 3.5（`anthropic.claude-3-5-haiku-20241022-v1:0`）が ap-northeast-1 に存在しない**ことが判明しました。このままデプロイすると口調変換が実行時に失敗（フォールバックで素の文章になる）するため、利用可能な Haiku 4.5 に差し替えます。

## 変更内容

- **PersonaRenderer**: `HAIKU_MODEL_ID` を `jp.anthropic.claude-haiku-4-5-20251001-v1:0`（JP推論プロファイル）に変更
- **api-stack**: HonoFn の Bedrock 権限 ARN を Haiku 4.5 に更新
- **agent-stack**: SaboriProposer Lambda が PersonaRenderer 経由で Haiku を呼ぶのに、従来 **Sonnet の権限しかなく Haiku 権限が欠落**していた → Haiku 4.5 の ARN を追加

## 確認

- ap-northeast-1 で `jp.anthropic.claude-haiku-4-5-20251001-v1:0` 推論プロファイルが利用可能と確認済み
- agent 174 テストパス。CDK synth(Agent/Api) で Haiku 4.5 ARN 反映を確認
- A〜D の E2E 実機確認の前提修正