### PR TITLE
fix(persona): ペルソナ変更の表示同期とアバターのペルソナ別見た目

### DIFF
--- a/pkgs/frontend/src/components/character/SaborouAvatar.tsx
+++ b/pkgs/frontend/src/components/character/SaborouAvatar.tsx
@@ -5,17 +5,143 @@
  *
  * 用途: チャットバブル発話者識別 / コメント欄 /
  *       設定画面のキャラタブなど 28〜48px の小サイズ箇所。
- * verdict 非依存（常に「おっとり笑顔」固定）。
+ *
+ * personaId に応じて背景色と表情を変える（D: ペルソナを一目で識別）。
+ * 未指定時は「おっとり」のオレンジ笑顔。
  */
+
+/** ペルソナ別の見た目（背景グラデーション・影色・表情タイプ） */
+type FaceType = "gentle" | "stern" | "calm" | "logical";
+
+interface PersonaLook {
+  gradient: string;
+  shadow: string;
+  face: FaceType;
+}
+
+const PERSONA_LOOKS: Record<string, PersonaLook> = {
+  saboru_ottori: {
+    gradient: "linear-gradient(135deg, #F97316, #EA580C)",
+    shadow: "rgba(249,115,22,0.3)",
+    face: "gentle",
+  },
+  saboru_strict: {
+    gradient: "linear-gradient(135deg, #4B5563, #1F2937)",
+    shadow: "rgba(31,41,55,0.35)",
+    face: "stern",
+  },
+  saboru_psy: {
+    gradient: "linear-gradient(135deg, #6366F1, #4F46E5)",
+    shadow: "rgba(99,102,241,0.3)",
+    face: "calm",
+  },
+  saboru_hacker: {
+    gradient: "linear-gradient(135deg, #10B981, #065F46)",
+    shadow: "rgba(16,185,129,0.3)",
+    face: "logical",
+  },
+};
+
+const DEFAULT_LOOK = PERSONA_LOOKS.saboru_ottori;
+
+/** 表情タイプごとの目・口の SVG パス */
+function FacePaths({ face }: { face: FaceType }) {
+  // 口は表情で変える
+  const mouth =
+    face === "gentle"
+      ? "M 17 26 Q 20 28 23 26" // 笑顔
+      : face === "stern"
+        ? "M 17 27 L 23 27" // 真一文字
+        : face === "calm"
+          ? "M 17 26 Q 20 27 23 26" // 穏やかな微笑
+          : "M 17 26 L 20 27 L 23 26"; // クール（やや尖り）
+
+  // 目は stern/logical はキリッと直線、gentle/calm は眠そうカーブ
+  const eyesSharp = face === "stern" || face === "logical";
+
+  return (
+    <>
+      {/* 頬（gentle/calm のみ） */}
+      {(face === "gentle" || face === "calm") && (
+        <>
+          <ellipse
+            cx="14"
+            cy="22"
+            rx="2"
+            ry="1.2"
+            fill="#FED7AA"
+            opacity="0.6"
+          />
+          <ellipse
+            cx="26"
+            cy="22"
+            rx="2"
+            ry="1.2"
+            fill="#FED7AA"
+            opacity="0.6"
+          />
+        </>
+      )}
+      {eyesSharp ? (
+        <>
+          <path
+            d="M 12 19 L 16 19"
+            stroke="#1F2937"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+          <path
+            d="M 24 19 L 28 19"
+            stroke="#1F2937"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+        </>
+      ) : (
+        <>
+          <path
+            d="M 12 19 Q 14 21 16 19"
+            stroke="#1F2937"
+            strokeWidth="1.8"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M 24 19 Q 26 21 28 19"
+            stroke="#1F2937"
+            strokeWidth="1.8"
+            fill="none"
+            strokeLinecap="round"
+          />
+        </>
+      )}
+      <path
+        d={mouth}
+        stroke="#1F2937"
+        strokeWidth="1.8"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </>
+  );
+}
 
 export interface SaborouAvatarProps {
   /** ピクセルサイズ（推奨: 28 / 36 / 48） */
   size?: number;
   /** className 追加用 */
   className?: string;
+  /** ペルソナ ID（saboru_ottori 等）。見た目を切り替える。未指定はおっとり */
+  personaId?: string;
 }
 
-export function SaborouAvatar({ size = 36, className }: SaborouAvatarProps) {
+export function SaborouAvatar({
+  size = 36,
+  className,
+  personaId,
+}: SaborouAvatarProps) {
+  const look = (personaId && PERSONA_LOOKS[personaId]) || DEFAULT_LOOK;
   return (
     <div
       className={className}
@@ -23,12 +149,12 @@ export function SaborouAvatar({ size = 36, className }: SaborouAvatarProps) {
         width: size,
         height: size,
         borderRadius: "30%",
-        background: "linear-gradient(135deg, #F97316, #EA580C)",
+        background: look.gradient,
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
         flexShrink: 0,
-        boxShadow: "0 2px 6px rgba(249,115,22,0.3)",
+        boxShadow: `0 2px 6px ${look.shadow}`,
       }}
       role="img"
       aria-label="サボロー"
@@ -38,33 +164,9 @@ export function SaborouAvatar({ size = 36, className }: SaborouAvatarProps) {
         width={size * 0.75}
         height={size * 0.75}
         style={{ overflow: "visible" }}
+        aria-hidden="true"
       >
-        {/* 頬 */}
-        <ellipse cx="14" cy="22" rx="2" ry="1.2" fill="#FED7AA" opacity="0.7" />
-        <ellipse cx="26" cy="22" rx="2" ry="1.2" fill="#FED7AA" opacity="0.7" />
-        {/* 眠そうな目 */}
-        <path
-          d="M 12 19 Q 14 21 16 19"
-          stroke="#1F2937"
-          strokeWidth="1.8"
-          fill="none"
-          strokeLinecap="round"
-        />
-        <path
-          d="M 24 19 Q 26 21 28 19"
-          stroke="#1F2937"
-          strokeWidth="1.8"
-          fill="none"
-          strokeLinecap="round"
-        />
-        {/* 笑顔 */}
-        <path
-          d="M 17 26 Q 20 28 23 26"
-          stroke="#1F2937"
-          strokeWidth="1.8"
-          fill="none"
-          strokeLinecap="round"
-        />
+        <FacePaths face={look.face} />
       </svg>
     </div>
   );

--- a/pkgs/frontend/src/pages/PersonaPage.tsx
+++ b/pkgs/frontend/src/pages/PersonaPage.tsx
@@ -23,7 +23,7 @@ export function PersonaPage() {
   const locale = i18n.language.startsWith("ja") ? "ja" : "en";
   const isJa = locale === "ja";
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, updateUser } = useAuth();
   const { showToast } = useToast();
   const [selected, setSelected] = useState<string>(DEFAULT_PERSONA_ID);
   const [saving, setSaving] = useState(false);
@@ -47,6 +47,8 @@ export function PersonaPage() {
     setSaving(true);
     updatePersona(id)
       .then(() => {
+        // AuthProvider の user も更新して、再訪時・他画面に即同期させる
+        updateUser({ preferredPersonaId: id });
         showToast(isJa ? "ペルソナを変更したよ" : "Persona updated", "success");
       })
       .catch(() => {
@@ -85,7 +87,7 @@ export function PersonaPage() {
             }}
           >
             <div className="flex items-center gap-2.5 mb-2.5">
-              <SaborouAvatar size={32} />
+              <SaborouAvatar size={32} personaId={current.id} />
               <div>
                 <p className="font-extrabold" style={{ fontSize: 13 }}>
                   {current.name[locale]}
@@ -154,7 +156,7 @@ export function PersonaPage() {
                       background: p.bg,
                     }}
                   >
-                    <SaborouAvatar size={26} />
+                    <SaborouAvatar size={26} personaId={p.id} />
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5">

--- a/pkgs/frontend/src/pages/SettingsPage.tsx
+++ b/pkgs/frontend/src/pages/SettingsPage.tsx
@@ -39,7 +39,7 @@ export function SettingsPage() {
           {/* プロフィール */}
           {user && (
             <div className="card-brutal p-3.5 flex items-center gap-3">
-              <SaborouAvatar size={48} />
+              <SaborouAvatar size={48} personaId={user.preferredPersonaId} />
               <div className="min-w-0">
                 <p
                   className="font-bold text-saboru-ink truncate"

--- a/pkgs/frontend/src/providers/AuthProvider.tsx
+++ b/pkgs/frontend/src/providers/AuthProvider.tsx
@@ -32,6 +32,8 @@ interface AuthContextValue extends AuthState {
     refreshToken: string,
     expiresIn: number,
   ) => Promise<void>;
+  /** ログイン中ユーザーの一部フィールドを更新する（例: ペルソナ変更の即時反映） */
+  updateUser: (patch: Partial<User>) => void;
 }
 
 const AuthContext = React.createContext<AuthContextValue | null>(null);
@@ -119,11 +121,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [],
   );
 
+  const updateUser = React.useCallback((patch: Partial<User>) => {
+    setState((prev) =>
+      prev.user ? { ...prev, user: { ...prev.user, ...patch } } : prev,
+    );
+  }, []);
+
   const value: AuthContextValue = {
     ...state,
     signIn,
     signOut,
     handleCallback,
+    updateUser,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
## 概要
実機テストで判明した2点に対応。

1. **同期バグ**: ペルソナ変更は DB 保存・判定反映とも正常だったが、AuthProvider の `user` が更新されず、設定画面に戻ると古い選択に見えた
2. **UX**: 人格が見た目で分からず識別しづらい

## 変更
- `AuthProvider` に `updateUser` 追加 → ペルソナ変更成功時に `user.preferredPersonaId` を即更新（再訪・他画面に同期）
- `SaborouAvatar` に `personaId` prop 追加。ペルソナごとに背景色＋表情を変える（おっとり=オレンジ笑顔 / 鬼コーチ=グレー真顔 / 心理士=青穏やか / エンジニア=緑クール）
- PersonaPage・SettingsPage で現在ペルソナの見た目を反映

## テスト・品質
- frontend 137 テストパス / 型チェック・カバレッジ閾値OK / Biome 166→165（悪化なし）
- ※ バックエンドは元々正常（DBに saboru_hacker 保存・判定に personaId 反映をログで確認済み）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatars now support persona-based appearance customization, allowing different visual styles based on selected character personas.
  * User persona preferences are now persisted in profile settings.

* **Bug Fixes**
  * Avatar display in settings and persona selection page now correctly reflects the selected persona.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mashharuki/AWS-SummitHackathon-2026/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->