### PR TITLE
feat(persona): トップ・タスクのキャラ体色と挨拶文の口調をペルソナ反映

### DIFF
--- a/pkgs/frontend/src/components/character/SaborouCharacter2D.tsx
+++ b/pkgs/frontend/src/components/character/SaborouCharacter2D.tsx
@@ -12,6 +12,19 @@ import { VERDICT_SVG_CONFIG } from "@/lib/verdictMeta";
  */
 import type { Verdict } from "@saboru/shared";
 
+/**
+ * ペルソナ別の体色オーバーライド。
+ * verdict は天気・表情で表現し続け、体の色だけ人格カラーにする
+ * （判定＝天気/表情、人格＝体色、と役割分担して両方を視認可能にする）。
+ */
+const PERSONA_BODY: Record<string, { bodyColor: string; bodyShadow: string }> =
+  {
+    saboru_ottori: { bodyColor: "#F97316", bodyShadow: "#EA580C" },
+    saboru_strict: { bodyColor: "#6B7280", bodyShadow: "#374151" },
+    saboru_psy: { bodyColor: "#6366F1", bodyShadow: "#4F46E5" },
+    saboru_hacker: { bodyColor: "#10B981", bodyShadow: "#065F46" },
+  };
+
 export interface SaborouCharacter2DProps {
   /** Sabori verdict（デフォルト: "can_saboru"） */
   verdict?: Verdict;
@@ -23,6 +36,8 @@ export interface SaborouCharacter2DProps {
   sleeping?: boolean;
   /** className 追加用 */
   className?: string;
+  /** ペルソナ ID。指定時は体色を人格カラーで上書きする（天気・表情は verdict 由来のまま） */
+  personaId?: string;
 }
 
 export function SaborouCharacter2D({
@@ -31,8 +46,12 @@ export function SaborouCharacter2D({
   animated = true,
   sleeping = false,
   className,
+  personaId,
 }: SaborouCharacter2DProps) {
-  const config = VERDICT_SVG_CONFIG[verdict];
+  const baseConfig = VERDICT_SVG_CONFIG[verdict];
+  const personaBody = personaId ? PERSONA_BODY[personaId] : undefined;
+  // 体色のみペルソナで上書き（その他は verdict 由来を維持）
+  const config = personaBody ? { ...baseConfig, ...personaBody } : baseConfig;
 
   return (
     <div

--- a/pkgs/frontend/src/lib/staticContent.ts
+++ b/pkgs/frontend/src/lib/staticContent.ts
@@ -103,6 +103,48 @@ export const PERSONAS: Persona[] = [
   },
 ];
 
+/* ─── ペルソナ別 トップ挨拶文 ──────────────────────────
+ * 「今日のサボロー」バナーの口調をペルソナごとに変える。
+ * 未設定・おっとりは i18n のデフォルト文言を使う（ここには含めない）。
+ */
+type BannerText = {
+  hasTask: { ja: string; en: string };
+  noTask: { ja: string; en: string };
+};
+
+export const PERSONA_BANNERS: Record<string, BannerText> = {
+  saboru_strict: {
+    hasTask: {
+      ja: "未完了 {{count}} 件。今やる必要はない。後回しで支障なし。",
+      en: "{{count}} open. No need to act now. Deferring is fine.",
+    },
+    noTask: {
+      ja: "タスクなし。やることがないなら休め。以上。",
+      en: "No tasks. Nothing to do—rest. That's all.",
+    },
+  },
+  saboru_psy: {
+    hasTask: {
+      ja: "{{count}} 件、気になっていますか？ 今は少し手放してみてもいいかもしれません。",
+      en: "{{count}} on your mind? It might be okay to set them down for now.",
+    },
+    noTask: {
+      ja: "今日は何もありませんね。その余白を、どう感じていますか？",
+      en: "Nothing today. How does that openness feel to you?",
+    },
+  },
+  saboru_hacker: {
+    hasTask: {
+      ja: "[pending] {{count}} 件 / [judgment] 後回し可 / [action] 今は放置で最適",
+      en: "[pending] {{count}} / [judgment] deferrable / [action] optimal to leave",
+    },
+    noTask: {
+      ja: "[pending] 0 件 / [action] 休息が最適解",
+      en: "[pending] 0 / [action] resting is optimal",
+    },
+  },
+};
+
 /* ─── ロードマップ定義 ───────────────────────────── */
 
 export interface RoadmapFeature {

--- a/pkgs/frontend/src/pages/TaskListPage.tsx
+++ b/pkgs/frontend/src/pages/TaskListPage.tsx
@@ -6,6 +6,7 @@ import { CandidateCard, TaskCard } from "@/components/task/TaskCard";
 import { SectionLabel } from "@/components/ui/SectionLabel";
 import { useAuth } from "@/hooks/useAuth";
 import { useTasks } from "@/hooks/useTasks";
+import { PERSONA_BANNERS } from "@/lib/staticContent";
 import { getDisplayName } from "@/lib/utils";
 /**
  * タスク一覧ページ — U-06-ui-redesign Phase 5 改修版
@@ -20,8 +21,9 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export function TaskListPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user } = useAuth();
+  const locale = i18n.language.startsWith("ja") ? "ja" : "en";
   const {
     tasks,
     candidates,
@@ -38,8 +40,19 @@ export function TaskListPage() {
   // 今日バナーの verdict: タスクが無い or 全部 can_saboru なら "can_saboru"、
   // それ以外は最も重い verdict を採用（MVP では can_saboru 固定でも OK）
   const bannerVerdict: Verdict = "can_saboru";
-  const bannerMessage =
-    activeTasks.length === 0
+  // 挨拶文: ペルソナ別文言があればそれを使う（口調を一貫させる）。
+  // 無い/おっとりは既存の i18n デフォルト文言。
+  const personaBanner = user?.preferredPersonaId
+    ? PERSONA_BANNERS[user.preferredPersonaId]
+    : undefined;
+  const bannerMessage = personaBanner
+    ? activeTasks.length === 0
+      ? personaBanner.noTask[locale]
+      : personaBanner.hasTask[locale].replace(
+          "{{count}}",
+          String(activeTasks.length),
+        )
+    : activeTasks.length === 0
       ? t("tasks.noTaskBanner")
       : t("tasks.hasTaskBanner", { count: activeTasks.length });
 
@@ -91,7 +104,11 @@ export function TaskListPage() {
               background: "linear-gradient(135deg, #FFF7ED 0%, #FFEDD5 100%)",
             }}
           >
-            <SaborouCharacter2D verdict={bannerVerdict} size={56} />
+            <SaborouCharacter2D
+              verdict={bannerVerdict}
+              size={56}
+              personaId={user?.preferredPersonaId}
+            />
             <div className="flex-1 min-w-0">
               <p
                 className="font-bold tracking-wider"


### PR DESCRIPTION
## 概要
設定アバターに続き、タスク一覧トップ「今日のサボロー」のキャラと挨拶文もペルソナで一貫して変わるようにする（実機テストでのUX要望）。

## 変更
- `SaborouCharacter2D` に `personaId` 追加。指定時は体色を人格カラーで上書き（天気・表情は verdict 由来を維持＝判定と人格を両方視認可能に）
- `staticContent` に `PERSONA_BANNERS` 追加。トップ挨拶文をペルソナ別口調に切替（鬼コーチ=冷徹 / 心理士=問いかけ / エンジニア=箇条書き / おっとり=既存i18n）
- TaskListPage が `preferredPersonaId` でキャラ体色・挨拶文を選択

## テスト・品質
- frontend 137 テストパス / 型チェック・カバレッジ閾値OK / Biome 166→165（悪化なし）

## スコープ外（残課題）
- タスク詳細の 3D キャラ（SaborouScene3D）の人格色は threejs マテリアル改修が必要なため別途。判定文の口調は既に personaId 対応済み。