### PR TITLE
fix(api): Slack OAuth コールバックを認証なしルートにする

### DIFF
--- a/pkgs/cdk/lib/stacks/api-stack.ts
+++ b/pkgs/cdk/lib/stacks/api-stack.ts
@@ -191,6 +191,18 @@ export class SaborouApiStack extends cdk.Stack {
       ),
     });
 
+    // Slack OAuth コールバック (認証なし)
+    // Slack からのブラウザリダイレクトで来るため JWT は付かない。
+    // CSRF は state パラメータの HMAC 署名検証（auth.ts verifyState）で担保する。
+    httpApi.addRoutes({
+      path: "/api/auth/slack/callback",
+      methods: [apigatewayv2.HttpMethod.GET],
+      integration: new apigatewayv2Integrations.HttpLambdaIntegration(
+        "SlackCallbackIntegration",
+        honoFn,
+      ),
+    });
+
     // メインルート (JWT 認証必須)
     // OPTIONS は除外: API Gateway の corsPreflight が preflight を自動処理する。
     // ANY に OPTIONS を含めると JWT Authorizer が preflight に 401 を返し CORS が壊れる。


### PR DESCRIPTION
## 概要
Slack 連携時、OAuth 承認後のコールバックで `{"message":"Unauthorized"}` になっていた。

## 原因
`/api/auth/slack/callback` が JWT オーソライザー必須の `/{proxy+}` ルートに含まれていた。Slack からのブラウザリダイレクトは JWT を持たないため、API Gateway が認証エラーで弾いていた。

## 修正
`/health` と同様、callback を**認証なしルート**として個別登録。CSRF は state パラメータの HMAC 署名検証（`auth.ts` verifyState）で担保しているのでセキュリティは保たれる。

CDK のみの変更（アプリコード変更なし）。Api スタック再デプロイ済み。