### PR TITLE
fix(api): Slack連携後のリダイレクト先をCloudFrontに設定

### DIFF
--- a/pkgs/cdk/lib/stacks/api-stack.ts
+++ b/pkgs/cdk/lib/stacks/api-stack.ts
@@ -82,6 +82,11 @@ export class SaborouApiStack extends cdk.Stack {
         // per-user の Slack Bot Token シークレット名プレフィックス
         // （遡及取得 API が認証ユーザーの Bot Token を取得するため）
         SLACK_BOT_TOKEN_SECRET_PREFIX: `saborou/slack-bot-token/`,
+        // Slack OAuth コールバック成功後のフロント（CloudFront）リダイレクト先。
+        // 未設定だと localhost:5173 にフォールバックしてしまう。
+        ...(props.frontendDomainName
+          ? { FRONTEND_URL: `https://${props.frontendDomainName}` }
+          : {}),
         // Bedrock: SaboriProposerAgent が API Lambda 内で直接 Bedrock を呼び出す
         BEDROCK_REGION: "ap-northeast-1",
       },


### PR DESCRIPTION
OAuth コールバック成功後、FRONTEND_URL 未設定で localhost:5173 にリダイレクトされていた。HonoFn に FRONTEND_URL=CloudFront を設定。連携コア処理（Bot Token保存・slackUserId紐付け）は成功済みで、リダイレクト先のみ修正。Api 再デプロイ済み。