### PR TITLE
fix(slack): チャンネル一覧取得に channels:read/groups:read を追加

### DIFF
--- a/pkgs/backend/src/routes/auth.ts
+++ b/pkgs/backend/src/routes/auth.ts
@@ -35,6 +35,10 @@ const SLACK_OAUTH_SCOPES = [
   "im:history",
   "mpim:history",
   "users:read",
+  // channels:read / groups:read: Bot 参加チャンネル一覧の取得（users.conversations）
+  // UI のチャンネル選択ドロップダウン（C-1/C-2）に必要
+  "channels:read",
+  "groups:read",
   // chat:write: サボり提案を Slack スレッドに返信する（インタラクティブ化）
   "chat:write",
 ].join(",");


### PR DESCRIPTION
GET /api/slack/channels（users.conversations）が missing_scope で500になっていた。SLACK_OAUTH_SCOPES に channels:read/groups:read を追加。C-1/C-2のチャンネル選択に必要。※スコープ追加のため既存連携ユーザーは再認可が必要。