### PR TITLE
fix(cdk): EventBridgeルールがSlackBackfillもTaskExtractorへ配信

### DIFF
--- a/pkgs/cdk/lib/stacks/webhook-stack.ts
+++ b/pkgs/cdk/lib/stacks/webhook-stack.ts
@@ -102,8 +102,9 @@ export class SaborouWebhookStack extends cdk.Stack {
       ruleName: `saborou-slack-to-task-extractor-${environment}`,
       description: "Route Slack events to TaskExtractor Lambda",
       eventPattern: {
-        source: ["saborou.webhook"],
-        detailType: ["SlackEvent"],
+        // SlackEvent: Webhook 由来（リアルタイム）／SlackBackfill: 遡及取得 API 由来（C-1）
+        source: ["saborou.webhook", "saborou.backend"],
+        detailType: ["SlackEvent", "SlackBackfill"],
       },
       targets: [
         new eventsTargets.LambdaFunction(props.agents.taskExtractorFn, {


### PR DESCRIPTION
C-1の遡及取得が publish する SlackBackfill(source: saborou.backend) をルールが拾っておらず、候補化されなかった（queued表示後も候補0件）。ルールパターンに saborou.backend/SlackBackfill を追加。Webhook再デプロイ済み。