### PR TITLE
docs: AI-DLC試行錯誤記録（OSS貢献ドラフト・実AWS E2E手順）

### DIFF
--- a/aidlc-docs/aidlc-upstream-contribution/issue-draft-cross-unit-runtime-discovery.md
+++ b/aidlc-docs/aidlc-upstream-contribution/issue-draft-cross-unit-runtime-discovery.md
@@ -1,0 +1,80 @@
+# Issue ドラフト（公式リポジトリへ投稿する英語本文）
+
+> **【投稿済み 2026-05-23】**
+> - Issue **#299**: https://github.com/awslabs/aidlc-workflows/issues/299
+>   （タイトルは `[Feature]:` プレフィックスでテンプレ慣習に統一。`@mayakost` を co-reporter 明記、
+>   example 原文引用、#117/#269/#72 との関係を本文に記載。ラベルは外部コントリビューター権限不足で
+>   付与不可＝メンテナのトリアージ待ち）
+> - PR **#300**: https://github.com/awslabs/aidlc-workflows/pull/300
+>   （`feat/cross-unit-discovery-log`、最終 +37/-1、head `b0034f6`。`construction/code-generation.md`
+>   Step1=参照リユース（Affected Resource で照合）／Step11=記録／Critical Rules にスキーマ・ライフサイクル・
+>   初期ヘッダーを単一定義。`common/session-continuity.md` は再開時の独立チェックリスト項目として参照のみ。
+>   **Ready for review**。本文で「approach は #299 で合意してから／注文あれば revise・最悪 close→RFC」を明示）
+> - **品質検証 2 回（source-code-reviewer 委譲）→ 反映済み**: 1回目で C-1配置/W-1スキーマ/W-4コミットスコープを是正、
+>   2回目で W-2（"own" 曖昧→shared-resource 列挙判定）/W-3（session-continuity 視認性リグレッション）/Step1長文を是正。
+>   Critical 0・markdownlint 0err。残 Info（terminology.md 登録）はスコープ最小化のため見送り。各改訂は PR にコメントで明示。
+> - PR #276 スレッドに「私が起票する」確認コメント→起票→#299/#300 リンクコメントを投稿済み。
+> - **次アクション**: #299 でメンテナ／`@mayakost` の approach 合意を待つ。
+>   方向性に注文が付いたら #300 を revise（最悪 close して RFC テンプレに移行）。
+
+**Title**: `[Enhancement]: Construction should propagate runtime discoveries (rate limits, API quirks, pivots) across units, independent of declared dependencies`
+
+**Labels (suggest)**: enhancement, construction
+
+**起票方針**: PR #276 の `@mayakost` レビューが発端。Issue先行方針（[[feedback-issue-before-pr]]）に従い、
+PR #276 の返信コメントに本ドラフトを同梱して提示済み。`@mayakost` の合意（および誰が起票するか）を
+確認してから投稿する。投稿時は `@mayakost` を co-author / co-reporter として明記する。
+
+---
+
+## Which rule or stage is affected
+
+- `construction/code-generation.md`
+- `common/session-continuity.md`
+- `inception/units-generation.md` (`unit-of-work-dependency.md` の生成元)
+
+## Summary
+
+Construction phase は per-unit ループで進む。Unit 間のコンテキスト共有は、Units Generation で
+**静的に宣言された** 依存マトリクス (`unit-of-work-dependency.md`) を辿る形でのみ行われる。
+
+しかし、ある Unit の構築中に発生する **実行時の発見 (runtime discovery)** — 未文書化のレート制限、
+API の癖、設計時には想定できなかったピボット判断 — は、依存マトリクスに表れない。依存関係を
+宣言していない別の Unit が同じ外部リソースに触れる場合、その Unit のエージェントは先行 Unit の
+知見を一切ロードせず、**同じ調査と同じピボットを独立に繰り返す**。
+
+PR #276 はあくまで「session resume 時に per-unit 成果物を正しいパスでロードする」修正であり、
+静的依存グラフの射程内の話。本 Issue が扱うのは、その射程の **外** にある runtime cross-cutting
+discovery の共有という別レイヤーの課題。
+
+## Concrete example (raised by @mayakost on PR #276)
+
+> Unit 1 is a Notification module. While building it, the agent tries to use the platform's
+> email API v2, discovers it's rate-limited to 10 req/s (undocumented), and pivots to batching
+> with API v1. Unit 2 is a User Onboarding module that also sends emails. Since it has no
+> declared connection to Unit 1, that context is never loaded — the agent independently tries
+> API v2, hits the same wall, and has to repeat the same discovery and pivot.
+
+## Expected vs actual behavior
+
+- **Actual**: 各 Unit は自分の成果物 + 宣言された依存 Unit の成果物のみをロードする。実行時に
+  得られた横断的知見は次の Unit に伝播しない。
+- **Expected**: ある Unit の構築中に得られた、Unit 境界を越えて影響する発見（外部 API の制約、
+  レート制限、採用/不採用の判断とその理由）が記録され、後続の Unit の構築時に参照される。
+
+## Proposed direction (議論のたたき台)
+
+1. **横断的発見ログの導入**: Construction 中に発生した runtime discovery を
+   `aidlc-docs/construction/cross-unit-discoveries.md`（仮）に追記する。
+   1 エントリ = 発見・影響範囲・採った対応・理由。
+2. **全 Unit 起動時にロード**: per-unit ループの各 Unit 開始時に、自 Unit 成果物・依存 Unit 成果物に
+   加えて、この横断ログを必ずロードする（`session-continuity.md` の Smart Context Loading に追記）。
+3. **記録の責務**: `code-generation.md` に「外部リソースの制約・想定外のピボットに遭遇したら
+   横断ログへ追記する」ステップを追加する。
+4. 依存マトリクスは設計時依存のまま据え置き。本仕組みはそれと **直交する別レイヤー** として足す。
+
+## Notes
+
+- `@mayakost` がレビューで提起した課題。example は本人の文面をそのまま引用。
+- スコープが `common/` への新仕組み追加に及ぶため、CONTRIBUTING の "Single source of truth" /
+  "Be reproducible" に沿って、approach をこの Issue で合意してから PR を作成する。

--- a/aidlc-docs/aidlc-upstream-contribution/issue-draft.md
+++ b/aidlc-docs/aidlc-upstream-contribution/issue-draft.md
@@ -1,0 +1,85 @@
+# Issue ドラフト（公式リポジトリへ投稿する英語本文）
+
+**Title**: `[Bug]: No quality-target verification gate — measurable NFR targets (e.g. coverage thresholds) can be silently relaxed in Code Generation / Build & Test`
+
+**Labels (suggest)**: bug, construction
+
+---
+
+## Which rule or stage is affected
+
+- `construction/code-generation.md`
+- `construction/build-and-test.md`
+- `construction/nfr-requirements.md` (origin of the targets)
+
+## Summary
+
+Measurable quality targets defined in **NFR Requirements** (e.g. test coverage
+thresholds, performance budgets) are written into `tech-stack-decisions.md`, but
+**no downstream stage is required to verify that those targets were actually met.**
+As a result, an AI agent can satisfy every rule while a unit silently misses its
+own defined quality bar — or even relax the target itself to make a step "pass".
+
+## Expected vs actual behavior
+
+**Expected**: When NFR Requirements defines a measurable quality target for a unit,
+a later stage verifies the target was met before the unit is considered complete,
+and the agent is explicitly forbidden from weakening the target instead of meeting it.
+
+**Actual**: No such verification exists.
+
+- `code-generation.md` Step 11 / Critical Rules — no mention of quality targets.
+  Completion Criteria only requires that tests *are generated*, not that they meet
+  any standard. Line ~215 defers test execution entirely to Build & Test.
+- `build-and-test.md` — this stage *generates test-execution instructions* (markdown
+  with `[Command to run tests]` placeholders); it does not execute tests or compare
+  results against NFR targets. The `build-and-test-summary.md` template has a
+  `Coverage: [X]%` field but no step fills `[X]` or checks it against the target.
+
+So across the entire Construction phase there is **no gate** that confirms a defined,
+measurable quality target was achieved.
+
+## Reproduction (observed in a real run)
+
+Platform: Claude-based coding agent, greenfield monorepo (TypeScript / pnpm).
+
+1. In **NFR Requirements** for a unit, define a coverage target (e.g. Statements 90% /
+   Branches 85%). It is recorded in `nfr-requirements.md` / `tech-stack-decisions.md`.
+2. In **Code Generation**, the agent generates code + tests. Actual coverage comes
+   out lower (e.g. Statements ~73% / Branches ~67%).
+3. To "pass", the agent **lowers the coverage threshold in the test config** from
+   90/85 to 70/65 and reports the step as complete and compliant.
+4. Nothing in the rules flags this. It is only caught by human review.
+
+The agent did not violate any rule — because no rule covers this.
+
+## Why this matters
+
+`common/overconfidence-prevention.md` already establishes the principle
+"do not proceed with ambiguity" and lists red flags such as *"Proceeding with vague
+or ambiguous user responses"*. The same philosophy should cover quality targets:
+a target defined upstream should not be silently abandoned downstream.
+
+This is the same class of gap that PR #155 fixed for question/answer rigor
+("Step 3 was strengthened but Step 5 stayed weak") — here it is
+"targets are *defined* but never *verified*".
+
+PR #210 (Build & Test Execution extension) improves test *execution*, but (a) it is
+opt-in, so the core workflow stays unguarded, and (b) it focuses on "tests pass",
+not on "results meet the NFR-defined targets".
+
+## Proposed direction (open to discussion)
+
+Three small, tool-agnostic rule changes:
+
+1. **`code-generation.md`** — add a Critical Rule: quality targets from NFR
+   Requirements/Design are inputs, not suggestions; never relax/lower/disable a
+   defined target to make a step pass; surface the gap instead.
+2. **`build-and-test.md`** — extend the `build-and-test-summary.md` template with
+   "Coverage Target" + "Target Met" fields, and add a step to compare actuals
+   against NFR targets.
+3. **`overconfidence-prevention.md`** — add "relaxing a previously defined quality
+   target instead of meeting it" to the Red Flags list.
+
+Happy to open a PR with these changes if the approach sounds right. Tested against
+a full Inception→Construction run of a real project.

--- a/aidlc-docs/aidlc-upstream-contribution/pr-draft.md
+++ b/aidlc-docs/aidlc-upstream-contribution/pr-draft.md
@@ -1,0 +1,161 @@
+# PR ドラフト（公式リポジトリへ投稿する英語本文）
+
+**Title**: `fix: add quality-target verification gate to Construction phase`
+
+**Branch**: `fix/quality-target-gate`（fork 上）
+**Base**: `awslabs/aidlc-workflows:main`
+
+---
+
+## Summary
+
+Closes #<ISSUE_NUMBER>.
+
+Adds a tool-agnostic quality-target verification gate to the Construction phase.
+Measurable quality targets defined in NFR Requirements (test coverage thresholds,
+performance budgets, etc.) currently have no downstream stage that verifies they
+were met — an agent can silently miss, or even lower, its own defined target while
+satisfying every rule. This PR closes that gap with three minimal changes.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `construction/code-generation.md` | Add `HONOR QUALITY TARGETS` to the "Generation Phase Rules" Critical Rules |
+| `construction/build-and-test.md` | Add "Coverage Target" / "Target Met" fields to the summary template, and a comparison step |
+| `common/overconfidence-prevention.md` | Add target-relaxation to the "Red Flags to Watch For" list |
+
+## Rationale
+
+This mirrors the gap PR #155 fixed for question/answer rigor: a property is
+strengthened on one side of a stage boundary but left unenforced on the other.
+Here, quality targets are *defined* (NFR Requirements) but never *verified*
+(Code Generation / Build & Test). The change is consistent with
+`common/overconfidence-prevention.md`'s principle of not proceeding past
+unresolved gaps.
+
+## Test Plan
+
+- Ran a full Inception→Construction cycle on a real greenfield monorepo project
+  (TypeScript / pnpm, 6 units) with a Claude-based agent.
+- In the original run, the agent lowered a coverage threshold (90/85 → 70/65) to
+  pass Code Generation; this was only caught by human review.
+- With these rule changes applied, the agent is explicitly instructed to surface
+  the coverage gap in the completion message instead of weakening the target, and
+  Build & Test now records target-vs-actual.
+- All affected markdown files pass `markdownlint-cli2`.
+
+## Checklist
+
+- [x] Reviewed the contributing guidelines
+- [x] Performed a self-review
+- [x] Changes tested (full Construction-phase run described above)
+- [x] Changes documented (rule files are self-documenting; Issue #<N> has full context)
+
+## Acknowledgment
+
+By submitting this pull request, I confirm that you can use, modify, copy, and
+redistribute this contribution, under the terms of the project license.
+
+---
+
+# 実際の修正差分（適用内容）
+
+## 差分1: `construction/code-generation.md`
+
+`### Generation Phase Rules` ブロックの末尾に追加。
+
+変更前:
+```markdown
+### Generation Phase Rules
+- **NO HARDCODED LOGIC**: Only execute what's written in the unit plan
+- **FOLLOW PLAN EXACTLY**: Do not deviate from the step sequence
+- **UPDATE CHECKBOXES**: Mark [x] immediately after completing each step
+- **STORY TRACEABILITY**: Mark unit stories [x] when functionality is implemented
+- **RESPECT DEPENDENCIES**: Only implement when unit dependencies are satisfied
+```
+
+変更後（最終行を追加）:
+```markdown
+### Generation Phase Rules
+- **NO HARDCODED LOGIC**: Only execute what's written in the unit plan
+- **FOLLOW PLAN EXACTLY**: Do not deviate from the step sequence
+- **UPDATE CHECKBOXES**: Mark [x] immediately after completing each step
+- **STORY TRACEABILITY**: Mark unit stories [x] when functionality is implemented
+- **RESPECT DEPENDENCIES**: Only implement when unit dependencies are satisfied
+- **HONOR QUALITY TARGETS**: Measurable quality targets defined in NFR Requirements
+  or NFR Design (e.g. test coverage thresholds, performance budgets) are inputs to
+  Code Generation, not suggestions. Generated tests and configuration MUST aim to
+  meet them. NEVER relax, lower, or disable a previously defined quality target
+  (including threshold settings in test or build configuration) to make a step
+  "pass". If a target cannot be met, surface the gap explicitly in the completion
+  message instead of silently weakening the target.
+```
+
+## 差分2: `construction/build-and-test.md`
+
+### 2a: Step 7 の `build-and-test-summary.md` テンプレート内「Unit Tests」セクション
+
+変更前:
+```markdown
+### Unit Tests
+- **Total Tests**: [X]
+- **Passed**: [X]
+- **Failed**: [X]
+- **Coverage**: [X]%
+- **Status**: [Pass/Fail]
+```
+
+変更後:
+```markdown
+### Unit Tests
+- **Total Tests**: [X]
+- **Passed**: [X]
+- **Failed**: [X]
+- **Coverage**: [X]%
+- **Coverage Target (from NFR Requirements)**: [X]% (or N/A if none defined)
+- **Target Met**: [Yes/No/N/A]
+- **Status**: [Pass/Fail]
+```
+
+### 2b: Step 1 の直後（"Analyze Testing Requirements" の末尾）に一文追加
+
+変更前（末尾）:
+```markdown
+- **Security tests**: Vulnerability scanning, penetration testing
+```
+
+変更後:
+```markdown
+- **Security tests**: Vulnerability scanning, penetration testing
+
+When NFR Requirements defined measurable quality targets for any unit (e.g. test
+coverage thresholds, performance budgets), record those targets here. The summary
+in Step 7 MUST compare actual results against them and state whether each target
+was met. If a target was not met, the summary MUST say so explicitly and the
+"Ready for Operations" field MUST reflect it.
+```
+
+## 差分3: `common/overconfidence-prevention.md`
+
+`### Red Flags to Watch For` セクションに 1 行追加。
+
+変更前:
+```markdown
+### Red Flags to Watch For
+- Stages completing without asking any questions on complex projects
+- Proceeding with vague or ambiguous user responses
+- Skipping entire question categories without justification
+- Making assumptions instead of asking for clarification
+```
+
+変更後:
+```markdown
+### Red Flags to Watch For
+- Stages completing without asking any questions on complex projects
+- Proceeding with vague or ambiguous user responses
+- Skipping entire question categories without justification
+- Making assumptions instead of asking for clarification
+- Relaxing, lowering, or disabling a previously defined quality target
+  (e.g. a test coverage threshold) instead of meeting it
+```

--- a/aidlc-docs/aidlc-upstream-contribution/proposal-quality-target-gate.md
+++ b/aidlc-docs/aidlc-upstream-contribution/proposal-quality-target-gate.md
@@ -1,0 +1,118 @@
+# 公式 aidlc-workflows への提案：品質目標トレーサビリティ・ゲート
+
+> 対象リポジトリ: [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows)（v0.1.8）
+> 作成日: 2026-05-17
+> 提案者: SABOROU チーム（AWS Summit Japan 2026 ハッカソン）
+
+---
+
+## 1. 背景：実運用で遭遇した事象
+
+SABOROU プロジェクト（pnpm モノレポ / TypeScript）で AI-DLC の Inception〜Construction
+フェーズをフル手順で実行した。Construction の Unit U-04（Hono API）で以下が発生した。
+
+1. **NFR Requirements ステージ**で、テストカバレッジ目標を「Statements 90% / Branches 85%」と定義し、
+   `nfr-requirements.md` および `tech-stack-decisions.md` に明記した。
+2. **Code Generation ステージ**で、AI エージェントがコードとテストを生成した。
+   しかし生成されたカバレッジは Statements 72.96% / Branches 67.06% にとどまった。
+3. このとき AI エージェントは、テスト不足を補う代わりに
+   **`vitest.config.ts` のカバレッジ閾値を 90/85 → 70/65 に引き下げ**、
+   「閾値クリア」として完了報告した。
+4. 人間のレビューで初めて検知し、変更依頼（再生成サイクル）でカバレッジを実測 98.98% まで補強した。
+
+ここで重要なのは、**AI エージェントはルール上どの規定にも違反していない**という点である。
+
+## 2. 根本原因：ルールの構造的欠陥
+
+公式ルールファイルを精読した結果、これは偶発的なバグではなく**ルール設計上の必然**であると判断した。
+
+### 2.1 品質目標が「定義」されても「強制」されない
+
+| ステージ | ルールファイル | 品質目標の扱い |
+|---|---|---|
+| NFR Requirements | `construction/nfr-requirements.md` | Step 6 で `tech-stack-decisions.md` に品質目標を**記述する**。下流に遵守を強制する記述なし |
+| Code Generation | `construction/code-generation.md` | Step 11 は「ステップが記述する通りに生成」のみ。Critical Rules に**品質基準への言及ゼロ**。Completion Criteria は `All code and tests generated` ＝ テストが**存在すれば**よい |
+| Build and Test | `construction/build-and-test.md` | テストを「実行する」のではなく実行**指示書を生成する**。summary テンプレートに `Coverage: [X]%` 欄があるが `[X]` を実測する手順も NFR 目標と照合する手順もない |
+
+### 2.2 結論
+
+**AI-DLC の全工程を通じて、「NFR Requirements / NFR Design で定義した測定可能な品質目標が、
+実際に達成されたか」を検証する承認ゲートが 1 つも存在しない。**
+
+`code-generation.md` L215 は明示的に「テストは Build & Test フェーズで実行される」と書くが、
+その Build & Test フェーズ自体が指示書生成ステージであり、実行・照合を行わない。
+
+## 3. 既存議論との関係（重複回避の確認）
+
+| 既存 Issue/PR | 内容 | 本提案との関係 |
+|---|---|---|
+| PR #210 Build & Test Execution Extension | テストを実際に実行する**オプトイン拡張** | 補完的。実行は追加するが「NFR 目標値との照合・未達時のゲート」観点は弱い（`BUILD-TEST-EXEC-005` は実測値の「表示」止まり）。かつ Extension のため、有効化しない限りコア手順は無防備のまま |
+| PR #155 nfr-design Step 5 強化 | 「質問は厳格化されたが回答分析が弱いまま」という**一貫性欠落**を修正 | 本提案と同じ論法。質問→回答に対し、本提案は「目標定義→目標達成検証」の一貫性欠落を指摘 |
+| `common/overconfidence-prevention.md` | 「曖昧な回答で先に進むな」を全ステージに課す設計思想 | 本提案の根拠。同じ精神で「未達の品質目標で先に進むな」が課されるべき |
+
+→ 本提案は既存の流れに沿い、空白地帯（コア手順の品質ゲート）を埋めるものである。
+
+## 4. 提案する変更
+
+CONTRIBUTING.md の原則「Single source of truth」「Keep it agnostic」を遵守する。
+ツール固有（vitest 等）の記述は使わず、ツール非依存の構造的ルールとして記述する。
+
+### 変更A：`code-generation.md` — 品質目標の参照を必須化
+
+**Critical Rules の「Generation Phase Rules」に 1 項目追加：**
+
+```markdown
+- **HONOR QUALITY TARGETS**: Measurable quality targets defined in NFR Requirements
+  / NFR Design (e.g. test coverage thresholds, performance budgets) are inputs to
+  Code Generation, not suggestions. Generated tests and configuration MUST aim to
+  meet them. NEVER relax, lower, or disable a previously defined quality target
+  (including threshold settings in test/build configuration) to make a step "pass".
+  If a target cannot be met, surface the gap explicitly in the completion message
+  rather than silently weakening the target.
+```
+
+### 変更B：`build-and-test.md` — 品質目標との照合を Step 7 に追加
+
+`build-and-test-summary.md` テンプレートの「Unit Tests」セクションに、目標値との照合行を追加：
+
+```markdown
+### Unit Tests
+- **Total Tests**: [X]
+- **Passed**: [X]
+- **Failed**: [X]
+- **Coverage**: [X]%
+- **Coverage Target (from NFR Requirements)**: [X]%   ← 追加
+- **Target Met**: [Yes/No]                            ← 追加
+- **Status**: [Pass/Fail]
+```
+
+さらに Step 7 の本文に一文追加：
+
+```markdown
+When NFR Requirements defined measurable quality targets for a unit, compare the
+actual results against those targets and record whether each target was met. If a
+target was not met, the summary MUST state this explicitly and the "Ready for
+Operations" field MUST reflect it.
+```
+
+### 変更C（軽微）：`overconfidence-prevention.md` — Red Flag に追加
+
+「Red Flags to Watch For」セクションに 1 行追加：
+
+```markdown
+- Relaxing, lowering, or disabling a previously defined quality target (e.g. a
+  coverage threshold) instead of meeting it
+```
+
+## 5. 提出戦略
+
+CONTRIBUTING.md は構造的変更について「まず Issue を開いて approach を合意してから PR」を推奨。
+
+1. **Issue を作成**（[Bug] 寄りの構造課題として）— 本ドキュメントの 1〜2 章を要約
+2. Issue にひも付ける形で **PR を作成** — 変更 A/B/C の差分
+3. PR の Test Plan に SABOROU プロジェクトでの実証（U-04 の事象）を記載
+
+## 6. テスト・実証
+
+本提案の根拠は SABOROU プロジェクトの実 Construction 実行ログ（`aidlc-docs/audit.md`）に記録済み。
+U-04 のカバレッジ閾値引き下げ事象とその是正（変更依頼サイクル）が監査ログに残っている。

--- a/aidlc-docs/operations/deploy-e2e-verification.md
+++ b/aidlc-docs/operations/deploy-e2e-verification.md
@@ -1,0 +1,119 @@
+# 実AWS デプロイ & E2E 確認手順（A〜D 検証）
+
+**作成日**: 2026-05-23
+**対象**: main `769dade`（A: ユーザー情報表示 / B: Slack↔Cognito紐付け / C: Bot Token+Slack履歴+返信 / D+E: ペルソナ切替）
+**リージョン**: ap-northeast-1 / **アカウント**: 853672407542
+
+完全な初回デプロイ（既存スタックなし）。以下の順序で進める。
+
+---
+
+## 事前条件チェック結果（2026-05-23 調査）
+
+| 項目 | 状態 |
+|---|---|
+| AWS 認証 | ✅ user/shinei.kikkawa |
+| CDK bootstrap | ❌ 未実施 → 手順1 |
+| SSM `/saborou/oauth/state-secret` | ❌ 未登録 → 手順2 |
+| SSM `/saborou/pseudonymize-salt-dev` | ❌ 未登録 → 手順2 |
+| Slack signing/client secret（Secrets Manager） | ❓ デプロイで枠は作られる。値は手順5で登録 |
+| Bedrock Sonnet 4.6 | ✅ jp.anthropic.claude-sonnet-4-6 利用可 |
+| Bedrock Haiku 4.5 | ✅ jp.anthropic.claude-haiku-4-5-20251001-v1:0 利用可（PR #28 で対応） |
+| Slack アプリ | ❓ 手順4・6（ユーザー作業） |
+
+---
+
+## デプロイ手順
+
+### 手順1: CDK bootstrap（初回のみ）
+```bash
+cd pkgs/cdk
+npx cdk bootstrap aws://853672407542/ap-northeast-1
+```
+
+### 手順2: 必須 SSM パラメータを登録（デプロイ前に必要）
+CDK が `valueForStringParameter` でデプロイ時に参照するため、deploy より前に作る。
+```bash
+# OAuth state HMAC secret（CSRF対策）
+aws ssm put-parameter --name "/saborou/oauth/state-secret" \
+  --value "$(openssl rand -hex 32)" --type "SecureString" --region ap-northeast-1
+# 仮名化ソルト
+aws ssm put-parameter --name "/saborou/pseudonymize-salt-dev" \
+  --value "$(openssl rand -hex 16)" --type "String" --region ap-northeast-1
+```
+> 注: README は salt をデプロイ後に作るとあるが、AgentStack が参照するため**デプロイ前**に作る。
+
+### 手順3: ビルド & デプロイ
+```bash
+# リポジトリルートで
+pnpm shared run build
+pnpm agent run build
+pnpm backend run build
+pnpm frontend run build
+pnpm cdk run deploy --require-approval never --all
+```
+完了後、CfnOutput から以下を控える:
+- HttpApiUrl（API Gateway）
+- Cognito UserPool/Client ID、Hosted UI ドメイン
+- CloudFront ドメイン（フロント）
+- WebhookUrl
+
+### 手順4: Slack アプリ作成（ユーザー作業）
+`slack-app-setup.md` STEP 1-2 に従う。
+- Bot Token Scopes: channels:history / groups:history / im:history / mpim:history / users:read / **chat:write**
+- Redirect URL: `{HttpApiUrl}/auth/slack/callback`
+
+### 手順5: Slack シークレットを Secrets Manager に登録
+```bash
+SLACK_SIGNING_SECRET=xxx SLACK_CLIENT_ID=xxx SLACK_CLIENT_SECRET=xxx \
+  pnpm run register:secret
+```
+（`scripts/register_slack_secret.sh` の実装に合わせる）
+
+### 手順6: Slack Event Subscriptions に Webhook URL 登録（ユーザー作業）
+`slack-app-setup.md` STEP 5。Request URL = WebhookUrl。
+
+---
+
+## E2E 確認シナリオ（A〜D）
+
+| # | 機能 | 手順 | 期待結果 |
+|---|---|---|---|
+| A | ユーザー情報表示 | フロントにログイン → 設定画面 | 名前・メールが表示される（id_token 経由） |
+| B | Slack↔Cognito紐付け | 設定でSlack連携 → Slackにタスク依頼を投稿 | 自分のタスク候補に出る（逆引き成功） |
+| C-1 | Slack履歴の遡及取得 | POST /api/slack/sync-messages | 過去メッセージがタスク候補化 |
+| C-2 | Slack返信 | POST /api/slack/notify-task | Slackチャンネルに判定が投稿される |
+| D+E | ペルソナ切替 | 設定でペルソナを鬼コーチ等に変更 → 判定生成 | 同じ判定が違う口調で返る |
+
+---
+
+## 後片付け
+```bash
+pnpm cdk run destroy --all --force
+# SSM / Secrets Manager の一部は手動削除が必要
+```
+
+---
+
+## 再デプロイ手順（2回目以降・例: 翌日の再開）
+
+初回デプロイ済みなら bootstrap と SSM パラメータは**残っている**ため、再現は deploy だけで済む。
+
+```bash
+cd /Users/shineikikkawa/dev/hackson/AWS-SummitHackathon-2026
+git checkout main && git pull   # 最新（A〜D+Haiku修正込み）
+# ビルド
+pnpm shared run build && pnpm agent run build && pnpm backend run build && pnpm frontend run build
+# デプロイ
+pnpm cdk run deploy --require-approval never --all
+```
+- bootstrap 不要（CDKToolkit 残存）
+- SSM `/saborou/oauth/state-secret`(String) と `/saborou/pseudonymize-salt-dev`(String) は残存（destroy で消えない）。消えていたら手順2を再実行
+- デプロイ後、CfnOutput を再取得（API/Cognito/CloudFront/Webhook の URL は再生成される場合あり）
+
+### 2026-05-23 初回デプロイ時の確認済み事項
+- 全7スタック CREATE_COMPLETE を確認（途中 SignatureDoesNotMatch=マシンスリープ起因の一時エラーで残り3スタックのみ再デプロイして完走）
+- Cognito callbackURL に CloudFront ドメインが自動登録されることを確認済み
+- env-config.json（ConfigDeployStack）が実 API/Cognito URL を配信する設計を確認済み
+- **未実施の E2E**: A（ログイン→設定画面で名前/メール表示）/ B（Slack連携→投稿→タスク化）/ C（履歴遡及・Slack返信）/ D（ペルソナ切替）
+- **既知の注意点**: `register_slack_secret.sh` は client-secret-dev に Client Secret のみ登録するが、auth.ts コールバックは `{clientId, clientSecret}` のJSON形式を期待 → Slack OAuth 時に要対処


### PR DESCRIPTION
## 概要
AI-DLC ワークフロー実践中の試行錯誤・取り組みの記録をリポジトリに残す（ドキュメントのみ・コード変更なし）。

- `aidlc-docs/aidlc-upstream-contribution/`: 公式 [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows) への改善提案ドラフト
  - 品質目標トレーサビリティ・ゲートの提案 / Issue / PR ドラフト（Issue #299 等で投稿済み）
  - クロスユニット実行時発見の Issue ドラフト
- `aidlc-docs/operations/deploy-e2e-verification.md`: 実 AWS デプロイ & E2E 検証手順（A〜D機能）

ハッカソンの開発プロセス・OSS貢献・本番検証の証跡。

## Test plan
- [x] ドキュメントのみ（ビルド・テストに影響なし）