### PR TITLE
fix(frontend): 承認モーダルを中央寄せにし最大幅を拡大

### DIFF
--- a/pkgs/frontend/src/components/task/TaskApprovalModal.tsx
+++ b/pkgs/frontend/src/components/task/TaskApprovalModal.tsx
@@ -191,11 +191,20 @@ export function TaskApprovalModal({
     <dialog
       open
       ref={modalRef}
-      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center"
+      className="fixed inset-0 z-50 flex h-full w-full items-end justify-center bg-black/40 p-4 sm:items-center"
       aria-labelledby="approve-task-title"
-      style={{ border: "none", maxWidth: "none", margin: 0, padding: 0 }}
+      style={{
+        border: "none",
+        maxWidth: "none",
+        maxHeight: "none",
+        width: "100%",
+        height: "100%",
+        margin: 0,
+        padding: 0,
+        inset: 0,
+      }}
     >
-      <div className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
+      <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
         {/* ヘッダー（モック準拠: eyebrow + タイトル、温かみのある背景） */}
         <div
           className="flex items-start justify-between p-4"


### PR DESCRIPTION
## Summary
- native `<dialog open>` のデフォルト `width: max-content` / `inset: auto` により左寄りになっていた承認モーダルを、dialog 自体に `width/height/inset` を明示して中央寄せに修正
- 情報密度を改善するため内側コンテナの最大幅を `max-w-lg` → `max-w-2xl` に拡大

## Test plan
- [x] tsc --noEmit クリーン
- [x] biome check クリーン
- [ ] dev サーバーで「承認する」モーダルが中央に表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Task Approval Modal layout with expanded width and full-screen positioning for better visibility and usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mashharuki/AWS-SummitHackathon-2026/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->